### PR TITLE
feat: NDGL-23 회원가입 시 닉네임 자동생성

### DIFF
--- a/application/src/main/java/com/yapp/ndgl/application/auth/controller/AuthApi.java
+++ b/application/src/main/java/com/yapp/ndgl/application/auth/controller/AuthApi.java
@@ -40,7 +40,8 @@ public interface AuthApi {
                           "message": "요청에 성공하였습니다.",
                           "data": {
                             "uuid": "550e8400-e29b-41d4-a716-446655440000",
-                            "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                            "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                            "nickname": "로맨틱한 고양이"
                           }
                         }
                         """
@@ -112,7 +113,8 @@ public interface AuthApi {
                           "message": "요청에 성공하였습니다.",
                           "data": {
                             "uuid": "550e8400-e29b-41d4-a716-446655440000",
-                            "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                            "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                            "nickname": "로맨틱한 고양이"
                           }
                         }
                         """

--- a/application/src/main/java/com/yapp/ndgl/application/auth/controller/dto/AuthResponse.java
+++ b/application/src/main/java/com/yapp/ndgl/application/auth/controller/dto/AuthResponse.java
@@ -6,7 +6,9 @@ public record AuthResponse(
     @Schema(description = "유저 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
     String uuid,
     @Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-    String accessToken
+    String accessToken,
+    @Schema(description = "닉네임", example = "행복한 여행자")
+    String nickname
 ) {
 
 }

--- a/application/src/main/java/com/yapp/ndgl/application/auth/service/AuthService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.yapp.ndgl.application.auth.service;
 
+import com.yapp.ndgl.domain.user.User;
 import org.springframework.stereotype.Service;
 import com.yapp.ndgl.application.auth.controller.dto.AuthResponse;
 import com.yapp.ndgl.application.auth.controller.dto.UserCreateRequest;
@@ -18,7 +19,7 @@ public class AuthService {
 
     @Transactional
     public AuthResponse createUser(final UserCreateRequest request) {
-        String uuid = userDomainService.createUser(
+        User user = userDomainService.createUser(
             request.fcmToken(),
             request.deviceModel(),
             request.deviceOs(),
@@ -26,18 +27,18 @@ public class AuthService {
             request.appVersion()
         );
 
-        String accessToken = jwtTokenProvider.generateToken(uuid);
+        String accessToken = jwtTokenProvider.generateToken(user.getUuid());
 
-        return new AuthResponse(uuid, accessToken);
+        return new AuthResponse(user.getUuid(), accessToken, user.getNickname());
     }
 
     @Transactional(readOnly = true)
     public AuthResponse login(final UserLoginRequest request) {
-        userDomainService.findByUuid(request.uuid());
+        User user = userDomainService.findByUuid(request.uuid());
 
         String accessToken = jwtTokenProvider.generateToken(request.uuid());
 
-        return new AuthResponse(request.uuid(), accessToken);
+        return new AuthResponse(request.uuid(), accessToken, user.getNickname());
     }
 }
 

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/user/entity/UserEntity.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/user/entity/UserEntity.java
@@ -15,38 +15,43 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity extends BaseEntity {
 
-  @Column(nullable = false, unique = true, length = 36)
-  private String uuid;
+    @Column(nullable = false, unique = true, length = 36)
+    private String uuid;
 
-  @Column(nullable = false, length = 500)
-  private String fcmToken;
+    @Column(nullable = false, length = 500)
+    private String fcmToken;
 
-  @Column(length = 100)
-  private String deviceModel;
+    @Column(length = 100)
+    private String deviceModel;
 
-  @Column(length = 50)
-  private String deviceOs;
+    @Column(length = 50)
+    private String deviceOs;
 
-  @Column(length = 100)
-  private String deviceOsVersion;
+    @Column(length = 100)
+    private String deviceOsVersion;
 
-  @Column(length = 50)
-  private String appVersion;
+    @Column(length = 50)
+    private String appVersion;
 
-  @Builder
-  public UserEntity(
-      final String uuid,
-      final String fcmToken,
-      final String deviceModel,
-      final String deviceOs,
-      final String deviceOsVersion,
-      final String appVersion
-  ) {
-    this.uuid = uuid;
-    this.fcmToken = fcmToken;
-    this.deviceModel = deviceModel;
-    this.deviceOs = deviceOs;
-    this.deviceOsVersion = deviceOsVersion;
-    this.appVersion = appVersion;
-  }
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    @Builder
+    public UserEntity(
+        final String uuid,
+        final String fcmToken,
+        final String deviceModel,
+        final String deviceOs,
+        final String deviceOsVersion,
+        final String appVersion,
+        final String nickname
+    ) {
+        this.uuid = uuid;
+        this.fcmToken = fcmToken;
+        this.deviceModel = deviceModel;
+        this.deviceOs = deviceOs;
+        this.deviceOsVersion = deviceOsVersion;
+        this.appVersion = appVersion;
+        this.nickname = nickname;
+    }
 }

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/User.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/User.java
@@ -17,6 +17,7 @@ public class User {
   private final String deviceOs;
   private final String deviceOsVersion;
   private final String appVersion;
+  private final String nickname;
   private final LocalDateTime createdAt;
   private final LocalDateTime updatedAt;
 
@@ -25,7 +26,8 @@ public class User {
       final String deviceModel,
       final String deviceOs,
       final String deviceOsVersion,
-      final String appVersion
+      final String appVersion,
+      final String nickname
   ) {
     String uuid = UUID.randomUUID().toString();
     LocalDateTime now = LocalDateTime.now();
@@ -37,6 +39,7 @@ public class User {
         .deviceOs(deviceOs)
         .deviceOsVersion(deviceOsVersion)
         .appVersion(appVersion)
+        .nickname(nickname)
         .createdAt(now)
         .updatedAt(now)
         .build();

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/UserDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/UserDomainService.java
@@ -15,30 +15,32 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UserDomainService {
 
-  private final UserRepository userRepository;
+    private final UserRepository userRepository;
 
-  public String createUser(
-      final String fcmToken,
-      final String deviceModel,
-      final String deviceOs,
-      final String deviceOsVersion,
-      final String appVersion) {
-    User user = User.create(
-        fcmToken,
-        deviceModel,
-        deviceOs,
-        deviceOsVersion,
-        appVersion
-    );
+    public User createUser(
+        final String fcmToken,
+        final String deviceModel,
+        final String deviceOs,
+        final String deviceOsVersion,
+        final String appVersion) {
+        String nickname = UserNicknameGenerator.generate();
 
-    UserEntity savedUserEntity = userRepository.save(UserMapper.toEntity(user));
-    User savedUser = UserMapper.toDomain(savedUserEntity);
-    return savedUser.getUuid();
-  }
+        User user = User.create(
+            fcmToken,
+            deviceModel,
+            deviceOs,
+            deviceOsVersion,
+            appVersion,
+            nickname
+        );
 
-  public User findByUuid(final String uuid) {
-    return userRepository.findByUuid(uuid)
-        .map(UserMapper::toDomain)
-        .orElseThrow(() -> new GlobalException(UserErrorCode.NOT_FOUND_USER));
-  }
+        UserEntity savedUserEntity = userRepository.save(UserMapper.toEntity(user));
+        return UserMapper.toDomain(savedUserEntity);
+    }
+
+    public User findByUuid(final String uuid) {
+        return userRepository.findByUuid(uuid)
+            .map(UserMapper::toDomain)
+            .orElseThrow(() -> new GlobalException(UserErrorCode.NOT_FOUND_USER));
+    }
 }

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/UserMapper.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/UserMapper.java
@@ -12,6 +12,7 @@ public class UserMapper {
 			.deviceOs(user.getDeviceOs())
 			.deviceOsVersion(user.getDeviceOsVersion())
 			.appVersion(user.getAppVersion())
+			.nickname(user.getNickname())
 			.build();
 	}
 
@@ -24,6 +25,7 @@ public class UserMapper {
 			.deviceOs(entity.getDeviceOs())
 			.deviceOsVersion(entity.getDeviceOsVersion())
 			.appVersion(entity.getAppVersion())
+			.nickname(entity.getNickname())
 			.createdAt(entity.getCreatedAt())
 			.updatedAt(entity.getUpdatedAt())
 			.build();

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/UserNicknameGenerator.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/UserNicknameGenerator.java
@@ -1,0 +1,29 @@
+package com.yapp.ndgl.domain.user;
+
+import java.util.List;
+import java.util.Random;
+
+public final class UserNicknameGenerator {
+
+    private static final List<String> ADJECTIVES = List.of(
+        "행복한", "즐거운", "신나는", "평화로운", "아름다운", "멋진", "따뜻한",
+        "상쾌한", "활기찬", "편안한", "로맨틱한", "모험적인", "자유로운", "감성적인"
+    );
+
+    private static final List<String> NOUNS = List.of(
+        "강아지", "고양이", "토끼", "햄스터", "다람쥐", "여우", "늑대",
+        "곰", "사자", "호랑이", "표범", "치타", "코끼리", "기린",
+        "얼룩말", "사슴", "팬더", "펭귄", "오리", "백조", "독수리",
+        "올빼미", "참새", "비둘기", "까마귀", "까치", "앵무새", "공작",
+        "물고기", "고래", "돌고래", "상어", "문어", "오징어", "해파리",
+        "나비", "벌", "잠자리", "개미", "무당벌레", "사슴벌레", "장수풍뎅이"
+    );
+
+    private static final Random RANDOM = new Random();
+
+    public static String generate() {
+        String adjective = ADJECTIVES.get(RANDOM.nextInt(ADJECTIVES.size()));
+        String noun = NOUNS.get(RANDOM.nextInt(NOUNS.size()));
+        return adjective + " " + noun;
+    }
+}


### PR DESCRIPTION
> 🤖 **이 PR은 OpenAI GPT-5-mini를 사용하여 자동 생성되었습니다.**

## 요약
유저 닉네임 자동 생성 기능을 도입하고, 생성된 닉네임을 인증 응답에 포함하도록 인증/도메인 계층을 확장했습니다. 이로 인해 도메인 엔티티와 매퍼, 서비스, API 응답 스펙에 닉네임 필드가 추가되었습니다.

## 주요 변경 사항

### 닉네임 자동 생성 도입
- 도메인-서비스 레이어에서 가입 시 자동으로 닉네임을 생성합니다.
- 닉네임 생성기는 간단한 형용사 + 명사 조합 방식을 사용합니다.
- 생성된 닉네임은 인증 응답()에 포함되어 클라이언트로 전달됩니다.

세부사항:
-  추가: 정적 리스트(형용사, 명사)에서 무작위로 조합하여 닉네임 생성.
- 닉네임은 가입 흐름에서 한 번 생성되어 사용자 엔티티에 저장됩니다.

### 도메인 및 영속성 모델 변경
- 도메인 모델()에  필드 추가.
- JPA 엔티티()에  컬럼 추가 (, ).
- 에 닉네임 매핑 로직 추가 (Entity ↔ Domain).

세부사항:
- 빌더/생성자 등 도메인 객체 생성 시 닉네임을 포함하도록 변경.
- 영속화된 엔티티에 닉네임 필드가 항상 존재하도록 설계.

### 인증(서비스/API) 변경
-  DTO에  필드 추가 및 스키마 예시 갱신.
- 회원가입(createUser) 시 토큰 생성에  사용(기존의 로컬 uuid 사용 로직 정리).
- 로그인(login) 응답에도 닉네임 포함.

세부사항:
- 인증 응답 구조 변경으로 프론트엔드/클라이언트가 닉네임을 수신하여 화면에 표시 가능.
- 인증 토큰 생성 로직에서 UUID 소스의 일관성 확보.

### 서비스 시그니처/호출 영향
-  반환 타입이 에서  도메인 객체로 변경됨(호출부 수정 필요).
- 내부적으로 닉네임 생성 및 저장을 책임지므로 호출자에게 닉네임 정보 제공 가능.

세부사항:
- 다른 모듈/서비스에서 를 호출하고 UUID만 기대하던 경우 컴파일/런타임 영향 가능.

## 상세 구현 내용

### 새 기술/라이브러리
- 특이사항 없음 (표준 Java 라이브러리와 기존 코드만 사용).

### 아키텍처/구조 변경
- 닉네임 관련 필드는 도메인 레이어에서 생성·소유하고, 매퍼를 통해 RDB에 영속화됩니다.
- 설계 이유:
  - 닉네임은 사용자 생성 시 결정되는 도메인 속성이므로 도메인-서비스()에서 생성하도록 함으로써 일관성 유지.
  - 응답에 닉네임을 포함시키기 위해 애플리케이션 레이어()는 도메인에서 반환된 를 기반으로 토큰 생성 및 DTO 조합.

### 복잡한 로직
- 닉네임 생성 알고리즘:
  - 내부 정적 리스트 , 에서 무작위로 각각 하나를 선택하여 두 문자열을 결합(예: 로맨틱한 + 고양이 → 로맨틱한고양이).
  - 구현은 단순 랜덤 선택()이며, 현재 별도의 충돌(중복) 검사나 확률 균형 로직은 없음.

### 기술적 결정 및 배경
- 닉네임을 도메인-서비스에서 생성하도록 한 이유:
  - 사용자 생성의 원자성 보장: 닉네임 생성/할당/영속화가 하나의 트랜잭션 내에서 처리되어 데이터 불일치 위험 감소.
  - 외부 의존 최소화: 간단한 내부 생성기로 우선 도입 후 필요 시 고도화(예: 중복 방지, 외부 네이밍 서비스 연계) 검토.
-  확장: 클라이언트 초기 화면에서 닉네임을 바로 활용할 수 있도록 응답에 포함.

### 필요 설정
- DB 마이그레이션 필요:
  - 이 로 추가되었으므로 기존 데이터가 있는 경우 마이그레이션(기본값 부여 또는 기존 사용자 닉네임 생성 및 채움)이 필요합니다.
  - 마이그레이션 스크립트를 통해 기존 레코드에 대해 닉네임을 채우거나 컬럼을 일시적으로 nullable로 처리 후 순차 적용 권장.
- 코드 변경 노트:
  -  반환 타입 변경에 따른 호출부(타 모듈) 수정 필요.
  - 클라이언트 쪽에서  스펙 변화( 필드) 반영 필요.
- 기타 환경 변수/시크릿: 특이사항 없음.

## 트러블슈팅
- DB 스키마 변경 관련 문제:
  - 문제: 기존 테이블에 non-null 컬럼 추가 시 마이그레이션 실패 가능.
  - 해결: 마이그레이션 시 기본값 할당 또는 단계적 마이그레이션(컬럼 nullable로 추가 → 기존 행 채움 → nullable 제거) 권장.
- 닉네임 중복(충돌) 우려:
  - 문제: 현재 랜덤 조합 방식으로 중복이 발생할 수 있음(특히 사용자 수가 늘어날수록).
  - 대응: 이번 PR에서는 우선 단순 생성으로 구현. 이후 필요 시 고유성 검사(예: DB 유니크 제약, 충돌 시 재생성, 이름 충돌 확률 관리) 추가 예정.
- 시그니처 변경으로 인한 빌드/호환 문제:
  - 문제: 의 반환 타입 변경으로 컴파일 에러 발생 가능.
  - 해결: 연관 모듈(또는 호출 지점)에서 반환 타입 에 맞춰 수정 완료.
- 토큰 생성 로직의 일관성:
  - 문제: 가입 처리 중 토큰 생성 시 UUID 소스가 혼재할 여지 있었음.
  - 해결: 회원 생성 후 를 사용해 토큰을 생성하도록 정리하여 소스 일관성 확보.

끝.
