### PR TITLE
Feature/NDGL-74 여행 프로그램 목록 조회 API 추가

### DIFF
--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/TravelProgramApi.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/TravelProgramApi.java
@@ -1,0 +1,52 @@
+package com.yapp.ndgl.application.domains.travel.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+
+import com.yapp.ndgl.application.domains.travel.controller.dto.TravelProgramResponse;
+import com.yapp.ndgl.common.response.SuccessResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Travel Program", description = "여행 프로그램 관련 API")
+public interface TravelProgramApi {
+
+    @Operation(
+        summary = "여행 프로그램 목록 조회",
+        description = "여행 프로그램 전체 목록을 조회합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "성공",
+            content = @Content(
+                schema = @Schema(implementation = TravelProgramResponse.class),
+                examples = @ExampleObject(
+                    name = "SUCCESS",
+                    value = """
+                        {
+                          "code": "2000",
+                          "message": "요청에 성공하였습니다.",
+                          "data": [
+                            {
+                              "id": 1,
+                              "name": "빠니보틀",
+                              "profileImage": "https://example.com/thumbnail/panibottle.jpg",
+                              "type": "YOUTUBE"
+                            }
+                          ]
+                        }
+                        """
+                )
+            )
+        )
+    })
+    ResponseEntity<SuccessResponse<List<TravelProgramResponse>>> readTravelPrograms();
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/TravelProgramController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/TravelProgramController.java
@@ -1,0 +1,31 @@
+package com.yapp.ndgl.application.domains.travel.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.yapp.ndgl.application.domains.travel.controller.dto.TravelProgramResponse;
+import com.yapp.ndgl.application.domains.travel.facade.TravelProgramFacade;
+import com.yapp.ndgl.common.response.SuccessResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/travel-programs")
+@RestController
+public class TravelProgramController implements TravelProgramApi {
+
+    private final TravelProgramFacade travelProgramFacade;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<SuccessResponse<List<TravelProgramResponse>>> readTravelPrograms() {
+        List<TravelProgramResponse> response = travelProgramFacade.readTravelPrograms();
+        return ResponseEntity.ok(SuccessResponse.success(response));
+    }
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/TravelProgramResponse.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/TravelProgramResponse.java
@@ -1,0 +1,28 @@
+package com.yapp.ndgl.application.domains.travel.controller.dto;
+
+import com.yapp.ndgl.domain.travel.TravelProgram;
+import com.yapp.ndgl.domain.travel.type.TravelProgramType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TravelProgramResponse(
+    @Schema(description = "프로그램 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    Long id,
+    @Schema(description = "프로그램명", example = "빠니보틀", requiredMode = Schema.RequiredMode.REQUIRED)
+    String name,
+    @Schema(description = "프로그램 프로필 이미지 URL", example = "https://example.com/thumbnail/panibottle.jpg", nullable = true)
+    String profileImage,
+    @Schema(description = "프로그램 타입", example = "YOUTUBE", requiredMode = Schema.RequiredMode.REQUIRED)
+    TravelProgramType type
+) {
+
+    public static TravelProgramResponse from(final TravelProgram program) {
+        return new TravelProgramResponse(
+            program.getId(),
+            program.getName(),
+            program.getProfileImage(),
+            program.getType()
+        );
+    }
+
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/TravelProgramFacade.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/TravelProgramFacade.java
@@ -1,0 +1,23 @@
+package com.yapp.ndgl.application.domains.travel.facade;
+
+import java.util.List;
+
+import com.yapp.ndgl.application.common.annotation.Facade;
+import com.yapp.ndgl.application.domains.travel.controller.dto.TravelProgramResponse;
+import com.yapp.ndgl.application.domains.travel.service.TravelProgramService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Facade
+@RequiredArgsConstructor
+public class TravelProgramFacade {
+
+    private final TravelProgramService travelProgramService;
+
+    public List<TravelProgramResponse> readTravelPrograms() {
+        log.info("여행 프로그램 목록을 조회합니다.");
+        return travelProgramService.readTravelPrograms();
+    }
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/TravelProgramService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/TravelProgramService.java
@@ -1,0 +1,27 @@
+package com.yapp.ndgl.application.domains.travel.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.yapp.ndgl.application.domains.travel.controller.dto.TravelProgramResponse;
+import com.yapp.ndgl.domain.travel.TravelProgram;
+import com.yapp.ndgl.domain.travel.service.TravelProgramDomainService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TravelProgramService {
+
+    private final TravelProgramDomainService travelProgramDomainService;
+
+    @Transactional(readOnly = true)
+    public List<TravelProgramResponse> readTravelPrograms() {
+        List<TravelProgram> programs = travelProgramDomainService.findAll();
+        return programs.stream()
+            .map(TravelProgramResponse::from)
+            .toList();
+    }
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/TravelProgramRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/TravelProgramRepository.java
@@ -1,0 +1,8 @@
+package com.yapp.ndgl.domain.travel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.yapp.ndgl.domain.travel.entity.TravelProgramEntity;
+
+public interface TravelProgramRepository extends JpaRepository<TravelProgramEntity, Long> {
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/TravelProgram.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/TravelProgram.java
@@ -1,0 +1,16 @@
+package com.yapp.ndgl.domain.travel;
+
+import com.yapp.ndgl.domain.travel.type.TravelProgramType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TravelProgram {
+
+    private Long id;
+    private String name;
+    private String profileImage;
+    private TravelProgramType type;
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/TravelProgramMapper.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/TravelProgramMapper.java
@@ -1,0 +1,20 @@
+package com.yapp.ndgl.domain.travel.mapper;
+
+import com.yapp.ndgl.domain.travel.TravelProgram;
+import com.yapp.ndgl.domain.travel.entity.TravelProgramEntity;
+
+public class TravelProgramMapper {
+
+    public static TravelProgram toDomain(final TravelProgramEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return TravelProgram.builder()
+            .id(entity.getId())
+            .name(entity.getName())
+            .profileImage(entity.getProfileImage())
+            .type(entity.getType())
+            .build();
+    }
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/TravelProgramDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/TravelProgramDomainService.java
@@ -1,0 +1,26 @@
+package com.yapp.ndgl.domain.travel.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.yapp.ndgl.domain.travel.TravelProgram;
+import com.yapp.ndgl.domain.travel.mapper.TravelProgramMapper;
+import com.yapp.ndgl.domain.travel.repository.TravelProgramRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TravelProgramDomainService {
+
+    private final TravelProgramRepository travelProgramRepository;
+
+    @Transactional(readOnly = true)
+    public List<TravelProgram> findAll() {
+        return travelProgramRepository.findAll().stream()
+            .map(TravelProgramMapper::toDomain)
+            .toList();
+    }
+}


### PR DESCRIPTION
> 🤖 **이 PR은 OpenAI GPT-5-mini를 사용하여 자동 생성되었습니다.**

## 요약
- 여행 프로그램 조회 기능을 엔드투엔드로 추가했습니다 (9개 파일 추가, 231 insertions).  
- GET /api/v1/travel-programs 엔드포인트를 통해 DB의 여행 프로그램을 조회하여 도메인 → DTO로 매핑해 반환합니다.

## 주요 변경 사항
### API / Controller
- TravelProgramApi, TravelProgramController
  - GET /api/v1/travel-programs 엔드포인트 추가
  - Swagger(OpenAPI) 애노테이션으로 문서화(예제 응답 포함)
  - 컨트롤러는 Facade를 통해 비즈니스 로직을 위임하고 SuccessResponse 래퍼로 응답 반환

### 애플리케이션 계층 (Facade / Service)
- TravelProgramFacade
  - 간단한 로깅 후 TravelProgramService 호출 (애플리케이션 계층의 진입점 역할)
- TravelProgramService
  - 도메인 서비스(TravelProgramDomainService) 호출 후 도메인 모델을 DTO(TravelProgramResponse)로 변환

### 도메인 서비스 / 매퍼
- TravelProgramDomainService
  - JPA Repository를 이용해 엔티티 목록 조회 후 TravelProgram 도메인 모델로 매핑
- TravelProgramMapper
  - TravelProgramEntity → TravelProgram(도메인) 변환 로직(널 체크 포함)

### 영속성 레이어
- TravelProgramRepository (domain-rdb 모듈)
  - JpaRepository<TravelProgramEntity, Long> 인터페이스 추가
  - 도메인 엔티티(TravelProgramEntity)는 별도 모듈에 존재한다고 가정

### 도메인 모델 / DTO
- TravelProgram (도메인 모델, Lombok @Builder, @Getter)
- TravelProgramResponse (컨트롤러 DTO, Java record)
  - TravelProgram으로부터 변환하는 정적 팩토리 메서드 from 제공
  - TravelProgramType(enum)을 포함하여 타입 안전성 유지

### 공통/기타
- lombok, Spring Data JPA, Spring Web, Swagger(OpenAPI) 사용
- application.common.annotation.Facade 등 기존 공통 어노테이션 활용
- SuccessResponse 응답 래퍼 사용으로 응답 규격 통일

## 상세 구현 내용
### 새 기술/라이브러리
- io.swagger.v3.oas.annotations (OpenAPI)  
  - 사용 이유: API 문서 자동화 및 예제 제공
  - 예시: TravelProgramApi 인터페이스에 @Operation, @ApiResponses 등 적용
- Lombok (@RequiredArgsConstructor, @Builder, @Getter)  
  - 보일러플레이트 감소 목적
- Spring Data JPA (JpaRepository)  
  - TravelProgramRepository로 CRUD 기본 제공

사용 예시 (변환 흐름)


### 아키텍처/구조 변경
- 모듈화된 계층 구조 강화:
  - application 모듈: Controller / Facade / Service / DTO
  - domain-service 모듈: 도메인 모델, 매퍼, 도메인 서비스
  - domain-rdb 모듈: JPA 엔티티 및 Repository
- 설계 이유:
  - 관심사의 분리(프레젠테이션 / 애플리케이션 로직 / 도메인 로직 / 영속성)
  - 모듈 단위 유지보수 및 의존성 관리 용이성

### 복잡한 로직
- 복잡한 알고리즘은 없음. 조회 → 매핑 → 반환의 단순한 흐름으로 구현되었습니다.

### 기술적 결정
- Facade 패턴 도입: Controller가 직접 도메인/서비스 구현에 의존하지 않고, 애플리케이션 서비스 계층을 통해 비즈니스 로직을 전달하도록 설계
- DTO를 Java record로 정의: 불변성 유지 및 간결성 확보
- @Transactional(readOnly = true) 적용: 읽기 전용 최적화 의도

### 필요 설정
- JPA 엔티티 스캔/레포지토리 스캔 설정:
  - domain-rdb 모듈의 패키지(com.yapp.ndgl.domain.travel.repository)를 Spring Data JPA가 스캔하도록 설정 필요
- 모듈 의존성:
  - application 모듈이 domain-service 및 domain-rdb(또는 repository 인터페이스를 포함한 모듈)를 의존하도록 빌드 설정 확인 필요
- 환경변수/시크릿: 특이사항 없음

## 트러블 슈팅
- 트러블슈팅 사항 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 여행 프로그램 목록 조회 기능이 추가되었습니다. 사용자는 시스템에 등록된 모든 여행 프로그램을 조회할 수 있으며, 각 프로그램의 이름, 대표 이미지, 그리고 프로그램 유형 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->