### PR TITLE
Feature/NDGL-81 여행 콘텐츠 키워드 검색 API

### DIFF
--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/TravelTemplateApi.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/TravelTemplateApi.java
@@ -10,6 +10,7 @@ import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateHig
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateItineraryResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplatePopularResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateRecommendationResponse;
+import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateSearchResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateResponse;
 import com.yapp.ndgl.common.response.ErrorResponse;
 import com.yapp.ndgl.common.response.SliceResponse;
@@ -373,6 +374,54 @@ public interface TravelTemplateApi {
     })
     ResponseEntity<SuccessResponse<SliceResponse<TravelTemplateRecommendationResponse>>> readRecommendedTravelTemplates(
 		@CurrentUuid String uuid,
+        @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", required = false)
+        @RequestParam(value = "page", defaultValue = "0") final int page,
+        @Parameter(description = "페이지 사이즈", example = "20", required = false)
+        @RequestParam(value = "size", defaultValue = "20") @Min(value = 1, message = "size는 1 이상 입니다.") final int size
+    );
+
+    @Operation(
+        summary = "여행 템플릿 검색",
+        description = "키워드로 여행 템플릿을 검색합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "성공",
+            content = @Content(
+                schema = @Schema(implementation = TravelTemplateSearchResponse.class),
+                examples = @ExampleObject(
+                    name = "SUCCESS",
+                    value = """
+                        {
+                          "code": "2000",
+                          "message": "요청에 성공하였습니다.",
+                          "data": {
+                            "content": [
+                              {
+                                "travelId": "TRAVEL_001",
+                                "title": "도쿄 3박 4일 완벽 여행 가이드",
+                                "thumbnail": "https://example.com/thumbnail/tokyo.jpg",
+                                "programName": "빠니보틀",
+                                "programType": "YOUTUBE",
+                                "traveler": "빠니보틀 Pani Bottle",
+                                "country": "일본",
+                                "city": "도쿄",
+                                "nights": 3,
+                                "days": 4
+                              }
+                            ],
+                            "hasNext": true
+                          }
+                        }
+                        """
+                )
+            )
+        )
+    })
+    ResponseEntity<SuccessResponse<SliceResponse<TravelTemplateSearchResponse>>> searchTravelTemplates(
+        @Parameter(description = "검색 키워드", example = "도쿄", required = true)
+        @RequestParam(value = "keyword") final String keyword,
         @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", required = false)
         @RequestParam(value = "page", defaultValue = "0") final int page,
         @Parameter(description = "페이지 사이즈", example = "20", required = false)

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/TravelTemplateController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/TravelTemplateController.java
@@ -12,6 +12,7 @@ import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateHig
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateItineraryResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplatePopularResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateRecommendationResponse;
+import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateSearchResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateResponse;
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
 import com.yapp.ndgl.application.domains.travel.facade.TravelTemplateFacade;
@@ -77,6 +78,18 @@ public class TravelTemplateController implements TravelTemplateApi {
     ) {
         SliceResponse<TravelTemplateRecommendationResponse> response =
             travelTemplateFacade.readRecommendedTravelTemplates(uuid, page, size);
+        return ResponseEntity.ok(SuccessResponse.success(response));
+    }
+
+    @Override
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<SliceResponse<TravelTemplateSearchResponse>>> searchTravelTemplates(
+        @RequestParam(value = "keyword") final String keyword,
+        @RequestParam(value = "page", defaultValue = "0") final int page,
+        @RequestParam(value = "size", defaultValue = "20") final int size
+    ) {
+        SliceResponse<TravelTemplateSearchResponse> response =
+            travelTemplateFacade.searchTravelTemplates(keyword, page, size);
         return ResponseEntity.ok(SuccessResponse.success(response));
     }
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/TravelTemplateSearchResponse.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/TravelTemplateSearchResponse.java
@@ -1,0 +1,45 @@
+package com.yapp.ndgl.application.domains.travel.controller.dto;
+
+import com.yapp.ndgl.domain.travel.TravelTemplate;
+import com.yapp.ndgl.domain.travel.type.TravelProgramType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TravelTemplateSearchResponse(
+    @Schema(description = "여행 템플릿 ID", example = "TRAVEL_001", requiredMode = Schema.RequiredMode.REQUIRED)
+    String travelId,
+    @Schema(description = "영상 제목", example = "도쿄 3박 4일 완벽 여행 가이드", requiredMode = Schema.RequiredMode.REQUIRED)
+    String title,
+    @Schema(description = "영상 썸네일 URL", example = "https://example.com/thumbnail/tokyo.jpg", nullable = true)
+    String thumbnail,
+    @Schema(description = "프로그램명", example = "빠니보틀", requiredMode = Schema.RequiredMode.REQUIRED)
+    String programName,
+    @Schema(description = "프로그램 타입", example = "YOUTUBE", requiredMode = Schema.RequiredMode.REQUIRED)
+    TravelProgramType programType,
+    @Schema(description = "여행자 표시명", example = "빠니보틀 Pani Bottle", nullable = true)
+    String traveler,
+    @Schema(description = "국가", example = "일본", requiredMode = Schema.RequiredMode.REQUIRED)
+    String country,
+    @Schema(description = "도시", example = "도쿄", requiredMode = Schema.RequiredMode.REQUIRED)
+    String city,
+    @Schema(description = "박 수", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
+    Integer nights,
+    @Schema(description = "일 수", example = "4", requiredMode = Schema.RequiredMode.REQUIRED)
+    Integer days
+) {
+
+    public static TravelTemplateSearchResponse from(final TravelTemplate travelTemplate) {
+        return new TravelTemplateSearchResponse(
+            travelTemplate.getTravelId(),
+            travelTemplate.getTitle(),
+            travelTemplate.getThumbnail(),
+            travelTemplate.getTravelProgramName(),
+            travelTemplate.getTravelProgramType(),
+            travelTemplate.getTraveler(),
+            travelTemplate.getCountry(),
+            travelTemplate.getCity(),
+            travelTemplate.getNights(),
+            travelTemplate.getDays()
+        );
+    }
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/TravelTemplateFacade.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/TravelTemplateFacade.java
@@ -5,6 +5,7 @@ import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateHig
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateItineraryResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplatePopularResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateRecommendationResponse;
+import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateSearchResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateResponse;
 import com.yapp.ndgl.application.domains.travel.service.TravelTemplateService;
 import com.yapp.ndgl.common.response.SliceResponse;
@@ -45,5 +46,12 @@ public class TravelTemplateFacade {
     ) {
         log.info("추천 여행 템플릿 목록을 조회합니다. uuid = {}, page = {}, size = {}", uuid, page, size);
         return travelTemplateService.readRecommendedTravelTemplates(uuid, page, size);
+    }
+
+    public SliceResponse<TravelTemplateSearchResponse> searchTravelTemplates(
+        final String keyword, final int page, final int size
+    ) {
+        log.info("여행 템플릿 검색을 수행합니다. keyword = {}, page = {}, size = {}", keyword, page, size);
+        return travelTemplateService.searchTravelTemplates(keyword, page, size);
     }
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/TravelTemplateService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/TravelTemplateService.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateHighlightsResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateItineraryResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplatePopularResponse;
+import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateSearchResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateRecommendationResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.TravelTemplateResponse;
 import com.yapp.ndgl.application.domains.travel.event.TravelTemplateViewCountEvent;
@@ -219,6 +220,17 @@ public class TravelTemplateService {
         SliceResponse<TravelTemplate> templates = travelTemplateDomainService.findRecommendedTemplates(country, page, size);
         List<TravelTemplateRecommendationResponse> content = templates.getContent().stream()
             .map(TravelTemplateRecommendationResponse::from)
+            .toList();
+        return SliceResponse.of(content, templates.isHasNext());
+    }
+
+    @Transactional(readOnly = true)
+    public SliceResponse<TravelTemplateSearchResponse> searchTravelTemplates(
+        final String keyword, final int page, final int size
+    ) {
+        SliceResponse<TravelTemplate> templates = travelTemplateDomainService.findByKeyword(keyword, page, size);
+        List<TravelTemplateSearchResponse> content = templates.getContent().stream()
+            .map(TravelTemplateSearchResponse::from)
             .toList();
         return SliceResponse.of(content, templates.isHasNext());
     }

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/TravelTemplateRepositoryCustom.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/TravelTemplateRepositoryCustom.java
@@ -9,4 +9,6 @@ import com.yapp.ndgl.domain.travel.entity.TravelTemplateEntity;
 public interface TravelTemplateRepositoryCustom {
 
     List<TravelTemplateEntity> findRandomTemplates(String country, Pageable pageable);
+
+    List<TravelTemplateEntity> findByKeyword(String keyword, Pageable pageable);
 }

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/TravelTemplateRepositoryImpl.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/TravelTemplateRepositoryImpl.java
@@ -34,4 +34,24 @@ public class TravelTemplateRepositoryImpl implements TravelTemplateRepositoryCus
             .limit(pageable.getPageSize())
             .fetch();
     }
+
+    @Override
+    public List<TravelTemplateEntity> findByKeyword(final String keyword, final Pageable pageable) {
+        QTravelTemplateEntity travelTemplate = QTravelTemplateEntity.travelTemplateEntity;
+        BooleanBuilder where = new BooleanBuilder();
+        if (keyword != null) {
+            where.and(
+                travelTemplate.country.containsIgnoreCase(keyword)
+                    .or(travelTemplate.city.containsIgnoreCase(keyword))
+                    .or(travelTemplate.travelProgram.name.containsIgnoreCase(keyword))
+            );
+        }
+
+        return queryFactory.selectFrom(travelTemplate)
+            .leftJoin(travelTemplate.travelProgram).fetchJoin()
+            .where(where)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
 }

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/TravelTemplateDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/TravelTemplateDomainService.java
@@ -82,10 +82,7 @@ public class TravelTemplateDomainService {
     ) {
         Pageable pageable = PageRequest.of(page, size + 1);
 
-        List<TravelTemplateEntity> entities = travelTemplateRepository.findRandomTemplates(
-            country,
-            pageable
-        );
+        List<TravelTemplateEntity> entities = travelTemplateRepository.findRandomTemplates(country, pageable);
 
         boolean hasNext = entities.size() > size;
         List<TravelTemplate> content = entities.stream()
@@ -94,6 +91,36 @@ public class TravelTemplateDomainService {
             .toList();
 
         return SliceResponse.of(content, hasNext);
+    }
+
+    @Transactional(readOnly = true)
+    public SliceResponse<TravelTemplate> findByKeyword(
+        final String keyword, final int page, final int size
+    ) {
+        String normalizedKeyword = normalizeKeyword(keyword);
+        if (normalizedKeyword == null) {
+            return SliceResponse.of(List.of(), false);
+        }
+
+        Pageable pageable = PageRequest.of(page, size + 1);
+        List<TravelTemplateEntity> entities =
+            travelTemplateRepository.findByKeyword(normalizedKeyword, pageable);
+
+        boolean hasNext = entities.size() > size;
+        List<TravelTemplate> content = entities.stream()
+            .limit(size)
+            .map(TravelTemplateMapper::toDomain)
+            .toList();
+
+        return SliceResponse.of(content, hasNext);
+    }
+
+    private String normalizeKeyword(final String keyword) {
+        if (keyword == null) {
+            return null;
+        }
+        String trimmed = keyword.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
 }


### PR DESCRIPTION
> 🤖 **이 PR은 OpenAI GPT-5-mini를 사용하여 자동 생성되었습니다.**

## 요약
검색 키워드로 여행 템플릿을 조회하는 기능을 추가했습니다. API/컨트롤러, 서비스/페이사드, 도메인 레포지토리 및 매핑 DTO가 포함된 end-to-end 검색 흐름을 구현합니다.

## 주요 변경 사항
- 통계 요약
  - 8 files changed, 180 insertions(+), 4 deletions(-)
  - New file: TravelTemplateSearchResponse.java

### API / Controller
- 여행 템플릿 검색 API 추가
  - TravelTemplateApi에 OpenAPI 스펙(응답 예시 포함) 추가
  - TravelTemplateController에 검색 엔드포인트 구현 (GET /search, 파라미터: keyword, page, size)
  - 응답 형태: SuccessResponse<SliceResponse<TravelTemplateSearchResponse>>

### Application Service / Facade
- TravelTemplateFacade에 searchTravelTemplates 메서드 추가
  - 로그 출력 후 TravelTemplateService로 위임
- TravelTemplateService에 searchTravelTemplates 구현 추가
  - 도메인 서비스 호출 결과를 DTO 리스트로 변환하여 SliceResponse로 반환

### DTO
- TravelTemplateSearchResponse 레코드 추가
  - 필드: travelId, title, thumbnail, programName, programType, traveler, country, city, nights, days
  - TravelTemplate 도메인 객체로부터 변환하는 정적 from 메서드 포함

### 도메인 / Repository
- TravelTemplateRepositoryCustom 인터페이스에 findByKeyword 시그니처 추가
- TravelTemplateRepositoryImpl에 findByKeyword 구현 추가
  - QueryDSL 사용, BooleanBuilder로 country/city/travelProgram.name에 대해 containsIgnoreCase 조건 구성
  - travelProgram을 fetchJoin으로 함께 조회
  - offset/limit 기반의 페이징 처리

### 도메인 서비스
- TravelTemplateDomainService에 findByKeyword 추가
  - normalizeKeyword로 빈/공백 키워드 처리(빈 경우 빈 결과 반환)
  - PageRequest.of(page, size + 1) 패턴으로 hasNext 계산
  - 엔티티를 도메인으로 매핑 후 size로 잘라 반환

## 상세 구현 내용

### 새 기술/라이브러리
- 특이사항 없음

### 아키텍처/구조 변경
- 검색 요청 흐름: Controller -> Facade -> Application Service -> Domain Service -> Repository
  - 책임 분리: Controller는 입력/응답, Facade는 간단한 로깅/조합, Service는 변환/트랜잭션, DomainService는 도메인 조회 로직을 담당

### 복잡한 로직
- 페이징 및 hasNext 계산
  - PageRequest.of(page, size + 1)을 사용해 페이지당 size+1개를 조회하고, hasNext 여부를 entities.size() > size 로 판단
  - 반환 시 List.limit(size)로 실제 응답 크기를 size로 맞춤
- 키워드 정규화
  - normalizeKeyword는 null 또는 공백만 있는 키워드를 null로 변환하여 불필요한 DB 조회를 방지하고 빈 SliceResponse를 반환
- QueryDSL 조건 구성
  - BooleanBuilder를 사용해 country, city, travelProgram.name 컬럼에 대해 containsIgnoreCase를 OR 결합

### 기술적 결정 및 고려사항
- 문자열 검색 방식
  - containsIgnoreCase (LIKE %keyword%) 를 사용하여 구현의 단순성 및 빠른 적용을 선택
  - 대규모 트래픽/대용량 데이터에서는 성능 이슈 가능 — 필요 시 full-text index(예: DB의 FULLTEXT, ElasticSearch 등) 도입 고려 권장
- fetchJoin 사용
  - travelProgram을 fetchJoin으로 함께 조회하여 N+1 문제를 완화
  - 주의: fetchJoin과 페이징(offset/limit) 조합은 조인으로 인한 중복 결과 발생 가능성이 있어 상황에 따라 distinct 처리 또는 별도 DTO 전용 쿼리 검토 필요
- 인덱스 권고
  - country, city, travel_program.name 컬럼에 적절한 인덱스가 있는지 확인 권장 (LIKE '%keyword%' 패턴은 앞부분 와일드카드로 인해 인덱스 활용이 제한될 수 있음)

### 필요 설정
- 특이사항 없음

## 트러블 슈팅
- 빈 키워드/공백 키워드로 인한 불필요한 조회를 방지하기 위해 normalizeKeyword 추가 및 빈 결과 반환 로직을 적용했습니다.
- domain-service 내부의 잘못된 인자(문자열에 포함된 '-' 등) 사용을 바로잡아 findRandomTemplates 호출을 정상화했습니다.
- 페이징을 위한 size+1 패턴을 도입하면서 hasNext 판별 로직을 일관되게 적용했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 여행 템플릿 검색 기능: 키워드를 통해 여행 템플릿을 검색할 수 있습니다. 국가, 도시, 프로그램명 등 다양한 정보로 원하는 템플릿을 찾을 수 있으며, 페이지네이션을 통해 결과를 효율적으로 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->