### PR TITLE
Feature/NDGL-84 내 여행 목록 조회 API

### DIFF
--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelApi.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelApi.java
@@ -9,10 +9,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelContentCardResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelItineraryResponse;
 import com.yapp.ndgl.common.response.ErrorResponse;
+import com.yapp.ndgl.common.response.SliceResponse;
 import com.yapp.ndgl.common.response.SuccessResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -179,6 +181,56 @@ public interface UserTravelApi {
     })
     ResponseEntity<SuccessResponse<UpcomingUserTravelResponse>> getUpcomingUserTravel(
         @CurrentUuid String uuid
+    );
+
+    @Operation(
+        summary = "내 여행 예정 목록 조회",
+        description = "여행 시작일이 오늘보다 미래인 내 여행 목록을 시작일 오름차순으로 조회합니다.",
+        security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "성공",
+            content = @Content(
+                schema = @Schema(implementation = UpcomingUserTravelListResponse.class),
+                examples = @ExampleObject(
+                    name = "SUCCESS",
+                    value = """
+                        {
+                          "code": "2000",
+                          "message": "요청에 성공하였습니다.",
+                          "data": {
+                            "content": [
+                              {
+                                "id": 1,
+                                "title": "도쿄 3박 4일",
+                                "country": "JP",
+                                "city": "도쿄",
+                                "startDate": "2026-03-01",
+                                "endDate": "2026-03-04",
+                                "nights": 3,
+                                "days": 4,
+                                "templateId": 10,
+                                "thumbnail": "https://example.com/thumbnail.jpg",
+                                "profileImage": "https://example.com/profile.jpg"
+                              }
+                            ],
+                            "hasNext": true
+                          }
+                        }
+                        """
+                )
+            )
+        )
+    })
+    ResponseEntity<SuccessResponse<SliceResponse<UpcomingUserTravelListResponse>>> getUpcomingUserTravels(
+        @CurrentUuid String uuid,
+        @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", required = false)
+        @RequestParam(value = "page", defaultValue = "0") final int page,
+        @Parameter(description = "페이지 사이즈", example = "20", required = false)
+        @RequestParam(value = "size", defaultValue = "20")
+        @Min(value = 1, message = "size는 1 이상 입니다.") final int size
     );
 
     @Operation(

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelController.java
@@ -6,10 +6,12 @@ import org.springframework.web.bind.annotation.*;
 
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelContentCardResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelItineraryResponse;
 import com.yapp.ndgl.application.domains.travel.facade.UserTravelFacade;
+import com.yapp.ndgl.common.response.SliceResponse;
 import com.yapp.ndgl.common.response.SuccessResponse;
 
 import jakarta.validation.Valid;
@@ -45,7 +47,17 @@ public class UserTravelController implements UserTravelApi {
         return ResponseEntity.ok(SuccessResponse.success(response));
     }
 
-    // TODO 내 여행 목록 조회
+    @Override
+    @GetMapping("/upcoming/list")
+    public ResponseEntity<SuccessResponse<SliceResponse<UpcomingUserTravelListResponse>>> getUpcomingUserTravels(
+        @CurrentUuid String uuid,
+        @RequestParam(value = "page", defaultValue = "0") final int page,
+        @RequestParam(value = "size", defaultValue = "20") final int size
+    ) {
+        SliceResponse<UpcomingUserTravelListResponse> response =
+            userTravelFacade.getUpcomingUserTravels(uuid, page, size);
+        return ResponseEntity.ok(SuccessResponse.success(response));
+    }
 
     @Override
     @GetMapping("/{id}/content-card")

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/UpcomingUserTravelListResponse.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/UpcomingUserTravelListResponse.java
@@ -1,0 +1,49 @@
+package com.yapp.ndgl.application.domains.travel.controller.dto;
+
+import java.time.LocalDate;
+
+import com.yapp.ndgl.domain.travel.UserUpcomingTravel;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpcomingUserTravelListResponse(
+	@Schema(description = "유저 여행 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+	Long id,
+	@Schema(description = "여행 제목", example = "도쿄 3박 4일", requiredMode = Schema.RequiredMode.REQUIRED)
+	String title,
+	@Schema(description = "국가", example = "JP", requiredMode = Schema.RequiredMode.REQUIRED)
+	String country,
+	@Schema(description = "도시", example = "도쿄", requiredMode = Schema.RequiredMode.REQUIRED)
+	String city,
+	@Schema(description = "여행 시작일", example = "2026-03-01", requiredMode = Schema.RequiredMode.REQUIRED)
+	LocalDate startDate,
+	@Schema(description = "여행 종료일", example = "2026-03-04", requiredMode = Schema.RequiredMode.REQUIRED)
+	LocalDate endDate,
+	@Schema(description = "박 수", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
+	Integer nights,
+	@Schema(description = "일 수", example = "4", requiredMode = Schema.RequiredMode.REQUIRED)
+	Integer days,
+	@Schema(description = "원본 여행 템플릿 ID", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
+	Long templateId,
+	@Schema(description = "썸네일 URL", example = "https://example.com/thumbnail.jpg", nullable = true)
+	String thumbnail,
+	@Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg", nullable = true)
+	String profileImage
+) {
+
+	public static UpcomingUserTravelListResponse from(final UserUpcomingTravel userUpcomingTravel) {
+		return new UpcomingUserTravelListResponse(
+			userUpcomingTravel.getId(),
+			userUpcomingTravel.getTitle(),
+			userUpcomingTravel.getCountry(),
+			userUpcomingTravel.getCity(),
+			userUpcomingTravel.getStartDate(),
+			userUpcomingTravel.getEndDate(),
+			userUpcomingTravel.getNights(),
+			userUpcomingTravel.getDays(),
+			userUpcomingTravel.getTemplateId(),
+			userUpcomingTravel.getThumbnail(),
+			userUpcomingTravel.getProfileImage()
+		);
+	}
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserTravelFacade.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserTravelFacade.java
@@ -2,10 +2,12 @@ package com.yapp.ndgl.application.domains.travel.facade;
 
 import com.yapp.ndgl.application.common.annotation.Facade;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelContentCardResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelItineraryResponse;
 import com.yapp.ndgl.application.domains.travel.service.UserTravelService;
+import com.yapp.ndgl.common.response.SliceResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,13 @@ public class UserTravelFacade {
     public UpcomingUserTravelResponse getUpcomingUserTravel(final String uuid) {
         log.info("다가오는 사용자 여행을 조회합니다. uuid = {}", uuid);
         return userTravelService.getUpcomingUserTravel(uuid);
+    }
+
+    public SliceResponse<UpcomingUserTravelListResponse> getUpcomingUserTravels(
+        final String uuid, final int page, final int size
+    ) {
+        log.info("사용자의 예정 여행 목록을 조회합니다. uuid = {}, page = {}, size = {}", uuid, page, size);
+        return userTravelService.getUpcomingUserTravels(uuid, page, size);
     }
 
     public UserTravelContentCardResponse readUserTravelContentCard(final String uuid, final Long id) {

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserTravelService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserTravelService.java
@@ -11,15 +11,18 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelResponse;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelContentCardResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelItineraryResponse;
 import com.yapp.ndgl.common.exception.GlobalException;
 import com.yapp.ndgl.common.exception.TravelErrorCode;
+import com.yapp.ndgl.common.response.SliceResponse;
 import com.yapp.ndgl.domain.place.Place;
 import com.yapp.ndgl.domain.place.service.PlaceDomainService;
 import com.yapp.ndgl.domain.travel.TravelTemplate;
 import com.yapp.ndgl.domain.travel.TravelTemplatePlace;
 import com.yapp.ndgl.domain.travel.UserTravel;
+import com.yapp.ndgl.domain.travel.UserUpcomingTravel;
 import com.yapp.ndgl.domain.travel.UserTravelPlace;
 import com.yapp.ndgl.domain.travel.service.TravelTemplateDomainService;
 import com.yapp.ndgl.domain.travel.service.UserTravelDomainService;
@@ -81,6 +84,20 @@ public class UserTravelService {
 		Place place = upcomingPlace == null ? null : placeDomainService.findById(upcomingPlace.getPlaceId());
 
 		return UpcomingUserTravelResponse.of(upcomingTravel, upcomingPlace, place, objectMapper);
+	}
+
+	@Transactional(readOnly = true)
+	public SliceResponse<UpcomingUserTravelListResponse> getUpcomingUserTravels(
+		final String uuid, final int page, final int size
+	) {
+		User user = userDomainService.findByUuid(uuid);
+		SliceResponse<UserUpcomingTravel> upcomingTravels =
+			userTravelDomainService.findUpcomingTravelsByUserId(user.getId(), page, size);
+
+		List<UpcomingUserTravelListResponse> content = upcomingTravels.getContent().stream()
+			.map(UpcomingUserTravelListResponse::from)
+			.toList();
+		return SliceResponse.of(content, upcomingTravels.isHasNext());
 	}
 
 	@Transactional(readOnly = true)

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/query/UserUpcomingTravelSummary.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/query/UserUpcomingTravelSummary.java
@@ -1,0 +1,52 @@
+package com.yapp.ndgl.domain.travel.query;
+
+import java.time.LocalDate;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+
+@Getter
+public class UserUpcomingTravelSummary {
+
+	private final Long id;
+	private final String title;
+	private final String country;
+	private final String city;
+	private final LocalDate startDate;
+	private final LocalDate endDate;
+	private final Integer nights;
+	private final Integer days;
+
+	// template
+	private final Long templateId;
+	private final String thumbnail;
+	private final String profileImage;
+
+	@QueryProjection
+	public UserUpcomingTravelSummary(
+		final Long id,
+		final String title,
+		final String country,
+		final String city,
+		final LocalDate startDate,
+		final LocalDate endDate,
+		final Integer nights,
+		final Integer days,
+		final Long templateId,
+		final String thumbnail,
+		final String profileImage
+	) {
+		this.id = id;
+		this.title = title;
+		this.country = country;
+		this.city = city;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.nights = nights;
+		this.days = days;
+		this.templateId = templateId;
+		this.thumbnail = thumbnail;
+		this.profileImage = profileImage;
+	}
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserTravelRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserTravelRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import com.yapp.ndgl.domain.travel.entity.UserTravelEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserTravelRepository extends JpaRepository<UserTravelEntity, Long> {
+public interface UserTravelRepository extends JpaRepository<UserTravelEntity, Long>, UserTravelRepositoryCustom {
     Optional<UserTravelEntity> findTopByUserIdAndStartDateGreaterThanEqualOrderByStartDateAsc(
         Long userId, LocalDate startDate);
 

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserTravelRepositoryCustom.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserTravelRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.yapp.ndgl.domain.travel.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import com.yapp.ndgl.domain.travel.query.UserUpcomingTravelSummary;
+
+public interface UserTravelRepositoryCustom {
+
+	List<UserUpcomingTravelSummary> findUpcomingUserTravelsByUserId(
+		Long userId, LocalDate today, Pageable pageable);
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserTravelRepositoryImpl.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserTravelRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.yapp.ndgl.domain.travel.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yapp.ndgl.domain.travel.entity.QTravelTemplateEntity;
+import com.yapp.ndgl.domain.travel.entity.QUserTravelEntity;
+import com.yapp.ndgl.domain.travel.query.QUserUpcomingTravelSummary;
+import com.yapp.ndgl.domain.travel.query.UserUpcomingTravelSummary;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserTravelRepositoryImpl implements UserTravelRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<UserUpcomingTravelSummary> findUpcomingUserTravelsByUserId(
+		final Long userId, final LocalDate today, final Pageable pageable
+	) {
+		QUserTravelEntity userTravel = QUserTravelEntity.userTravelEntity;
+		QTravelTemplateEntity travelTemplate = QTravelTemplateEntity.travelTemplateEntity;
+
+		return queryFactory
+			.select(new QUserUpcomingTravelSummary(
+				userTravel.id,
+				userTravel.title,
+				userTravel.country,
+				userTravel.city,
+				userTravel.startDate,
+				userTravel.endDate,
+				userTravel.nights,
+				userTravel.days,
+				travelTemplate.id,
+				travelTemplate.thumbnail,
+				travelTemplate.profileImage
+			))
+			.from(userTravel)
+			.leftJoin(travelTemplate).on(travelTemplate.id.eq(userTravel.templateId))
+			.where(
+				userTravel.userId.eq(userId),
+				userTravel.startDate.gt(today)
+			)
+			.orderBy(userTravel.startDate.asc(), userTravel.id.asc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+	}
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/UserUpcomingTravel.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/UserUpcomingTravel.java
@@ -1,0 +1,24 @@
+package com.yapp.ndgl.domain.travel;
+
+import java.time.LocalDate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserUpcomingTravel {
+
+    private Long id;
+    private String title;
+    private String country;
+    private String city;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer nights;
+    private Integer days;
+    private Long templateId;
+    private String thumbnail;
+    private String profileImage;
+
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/UserUpcomingTravelMapper.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/UserUpcomingTravelMapper.java
@@ -1,0 +1,27 @@
+package com.yapp.ndgl.domain.travel.mapper;
+
+import com.yapp.ndgl.domain.travel.UserUpcomingTravel;
+import com.yapp.ndgl.domain.travel.query.UserUpcomingTravelSummary;
+
+public class UserUpcomingTravelMapper {
+
+	public static UserUpcomingTravel toDomain(final UserUpcomingTravelSummary summary) {
+		if (summary == null) {
+			return null;
+		}
+
+		return UserUpcomingTravel.builder()
+			.id(summary.getId())
+			.title(summary.getTitle())
+			.country(summary.getCountry())
+			.city(summary.getCity())
+			.startDate(summary.getStartDate())
+			.endDate(summary.getEndDate())
+			.nights(summary.getNights())
+			.days(summary.getDays())
+			.templateId(summary.getTemplateId())
+			.thumbnail(summary.getThumbnail())
+			.profileImage(summary.getProfileImage())
+			.build();
+	}
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserTravelDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserTravelDomainService.java
@@ -4,19 +4,25 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.yapp.ndgl.common.exception.GlobalException;
 import com.yapp.ndgl.common.exception.TravelErrorCode;
+import com.yapp.ndgl.common.response.SliceResponse;
 import com.yapp.ndgl.domain.travel.TravelTemplate;
 import com.yapp.ndgl.domain.travel.TravelTemplatePlace;
 import com.yapp.ndgl.domain.travel.UserTravel;
+import com.yapp.ndgl.domain.travel.UserUpcomingTravel;
 import com.yapp.ndgl.domain.travel.UserTravelPlace;
 import com.yapp.ndgl.domain.travel.entity.UserTravelEntity;
 import com.yapp.ndgl.domain.travel.entity.UserTravelPlaceEntity;
+import com.yapp.ndgl.domain.travel.mapper.UserUpcomingTravelMapper;
 import com.yapp.ndgl.domain.travel.mapper.UserTravelPlaceMapper;
 import com.yapp.ndgl.domain.travel.mapper.UserTravelMapper;
+import com.yapp.ndgl.domain.travel.query.UserUpcomingTravelSummary;
 import com.yapp.ndgl.domain.travel.repository.UserTravelPlaceRepository;
 import com.yapp.ndgl.domain.travel.repository.UserTravelRepository;
 import com.yapp.ndgl.domain.user.User;
@@ -107,5 +113,24 @@ public class UserTravelDomainService {
 		return placeEntities.stream()
 			.map(UserTravelPlaceMapper::toDomain)
 			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public SliceResponse<UserUpcomingTravel> findUpcomingTravelsByUserId(
+		final Long userId, final int page, final int size
+	) {
+		LocalDate today = LocalDate.now();
+		Pageable pageable = PageRequest.of(page, size + 1);
+
+		List<UserUpcomingTravelSummary> summaries =
+			userTravelRepository.findUpcomingUserTravelsByUserId(userId, today, pageable);
+
+		boolean hasNext = summaries.size() > size;
+		List<UserUpcomingTravel> content = summaries.stream()
+			.limit(size)
+			.map(UserUpcomingTravelMapper::toDomain)
+			.toList();
+
+		return SliceResponse.of(content, hasNext);
 	}
 }


### PR DESCRIPTION
> 🤖 **이 PR은 OpenAI GPT-5-mini를 사용하여 자동 생성되었습니다.**

## 요약
내 여행 중 예정된 여행 목록을 페이지 단위로 조회하는 API를 추가하고, 이를 위한 도메인/퍼시스턴스 계층의 조회 최적화(쿼리 프로젝션 + 커스텀 리포지토리)를 도입했습니다. 응답은 슬라이스 형태(SliceResponse)로  정보를 포함하여 반환합니다.

## 주요 변경 사항
### 1. 내 여행 예정 목록 조회 API 추가
- GET  엔드포인트 추가(컨트롤러/인터페이스/패사드/서비스 연계).
- 반환 타입:  (컨텐츠 + hasNext).
- 요청 파라미터: (0 기반), (최소 1). OpenAPI(Swagger) 문서화 및 예시 응답 추가.

### 2. 퍼시스턴스 최적화: 프로젝션 기반 조회 및 커스텀 리포지토리
- 데이터베이스 조회는 전체 엔터티를 로드하지 않고 필요한 필드만 선택하는 프로젝션()을 사용.
- 와의 을 통해 썸네일, 프로필 이미지를 함께 조회하여 추가 쿼리 최소화.
- 커스텀 리포지토리 구현에서 offset/limit 기반 조회를 수행하고, 요청한 을 읽어  여부를 판단.

### 3. 도메인/매퍼 추가
- 조회 결과를 표현하는 도메인 객체()와 이를 변환하는 매퍼() 추가.
- 퍼시스턴스 레이어에서 반환된 프로젝션을 도메인으로 변환한 뒤, 애플리케이션 서비스에서 컨트롤러 응답 DTO로 변환하여 계층 분리를 유지.

### 4. 애플리케이션 레이어 변경 (서비스/패사드/컨트롤러)
- 서비스 계층에  추가: 도메인 서비스 호출 후 컨트롤러용 DTO 리스트로 매핑하여  반환.
- 패사드에 관련 메서드 추가 및 로깅 보강.
- 컨트롤러 인터페이스에 Swagger 어노테이션 및 응답 스펙(예시 포함) 추가, 컨트롤러 구현체에 매핑 로직 추가.

### 5. 기존 리포지토리 확장
- 기존 가 커스텀 리포지토리 인터페이스를 상속하도록 변경되어 커스텀 구현()이 연동됩니다.

## 상세 구현 내용
### 새 기술/라이브러리
- QueryDSL의  및  사용: 프로젝션 클래스를 통해 필요한 컬럼만 선택적으로 조회.
- Spring Data /를 읽어 /을 적용.
- 기존의 공통 응답 포맷(, )을 재사용.

주의:  사용으로 인해 QueryDSL의 애노테이션 프로세서가 Q 클래스()를 생성하도록 빌드 설정이 필요합니다.

### 아키텍처/구조 변경
- 퍼시스턴스 레이어: 복잡한 조회는 JPA 엔티티 리포지토리 대신 커스텀 리포지토리(구현체)에서 처리하여 성능과 응답 페이로드를 최적화.
- 계층 분리: DB 프로젝션 → 도메인(서비스층) → 컨트롤러 DTO 흐름으로 변환을 두어 각 계층의 책임을 명확히 함.
- API는 슬라이스(즉시 전부 로드하지 않는 페이징 확인 방식)를 사용하여 클라이언트에  정보를 제공.

### 복잡한 로직
- 페이징 논리:
  - DB 조회 시 로 한 건을 더 읽어  판단.
  - 반환 컨텐츠는 로 자르고, 면 .
  - 정렬:  오름차순, 동일일자 내에서는 uid=1001(runner) gid=1001(runner) groups=1001(runner),4(adm),100(users),118(docker),999(systemd-journal) 오름차순(결정적 정렬 보장).
- 조인/프로젝션:
  - 과 를 하여 템플릿 정보(썸네일, 프로필)를 함께 가져옴.
  - 템플릿이 없을 수 있으므로 프로젝션 결과의 널 허용을 고려.

### 기술적 결정
- 프로젝션 + 커스텀 리포지토리를 선택한 이유:
  - 엔티티 전체를 로드하면 불필요한 연관 조회(N+1) 및 메모리 사용이 증가하므로 필요한 필드만 선택해 성능을 개선.
  - Slice 형태 응답은 클라이언트에서 더 자연스러운 무한 스크롤 UX를 지원.
- 도메인 매퍼를 둔 이유:
  - DB 스키마/프로젝션 변화가 서비스/컨트롤러에 직접적인 영향을 덜 미치게 하기 위함(결합도 감소).

### 필요 설정
- QueryDSL 애노테이션 프로세서 활성화 (Q 클래스 생성 필요).
-  빈이 컨텍스트에 등록되어 있어야 함(Impl에서 주입 사용).
- 스프링 컴포넌트 스캔 범위에 커스텀 리포지토리 구현 패키지가 포함되어야 함(일반적으로 문제 없음).
- 컨트롤러 파라미터 에 대한  유효성 적용.

## 트러블 슈팅
- QueryDSL Projection 관련: 가 생성되지 않아 빌드 오류가 발생함.
  - 해결: 빌드 설정에 QueryDSL annotation processor 추가 및 재빌드(IDE/CI 설정 확인).
- hasNext 판단의 off-by-one 문제:
  - 초기 구현에서 로 조회하여 를 잘못 계산함. 로 조회한 뒤 로 자르는 방식으로 수정.
- 템플릿이 존재하지 않을 경우 NPE 이슈:
  - 으로 템플릿을 조회하고, 프로젝션/매퍼에서 null-safe 하게 필드 처리하도록 수정(썸네일/프로필 nullable).
- Spring Data 리포지토리 빈 충돌:
  - 기존 리포지토리에 커스텀 인터페이스를 추가하면서 구현체 이름()이 스프링 컨벤션을 만족하지 않으면 빈을 찾지 못함. 구현체 네이밍과 패키지 스캔 확인으로 해결.
- 성능 고려사항(주목):
  - 현재는 offset 기반 페이지네이션을 사용함. 대용량 데이터셋/깊은 페이지에서는 성능 저하 우려가 있으므로, 필요 시 키셋 페이징(커서) 도입을 검토할 것.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 예정된 여행 목록을 페이지네이션으로 조회하는 기능이 추가되었습니다. 여행 제목, 위치, 기간, 템플릿 정보 등을 페이지 단위로 효율적으로 확인할 수 있으며, 페이지 번호와 크기를 커스터마이징하여 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->