### PR TITLE
Feature/ndgl 80 내 여행 수정 api

### DIFF
--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelApi.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelApi.java
@@ -7,9 +7,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PutMapping;
 
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.ReplaceUserTravelItineraryRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelPlaceStartTimesRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
@@ -218,6 +220,106 @@ public interface UserTravelApi {
         @Parameter(description = "사용자 여행 ID", example = "1", required = true)
         @PathVariable("id") final Long id,
         @Valid @RequestBody UpdateUserTravelRequest request
+    );
+
+    @Operation(
+        summary = "내 여행 일정 전체 수정",
+        description = "사용자 본인 여행의 전체 일정을 요청 목록으로 교체합니다.",
+        security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "성공",
+            content = @Content(
+                schema = @Schema(implementation = SuccessResponse.class),
+                examples = @ExampleObject(
+                    name = "SUCCESS",
+                    value = """
+                        {
+                          "code": "2000",
+                          "message": "요청에 성공하였습니다.",
+                          "data": {}
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "일정 요청 값이 잘못됨",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "INVALID_ITINERARY_REQUEST",
+                    value = """
+                        {
+                          "code": "TRAVEL-04-002",
+                          "message": "여행 일정 요청 값이 올바르지 않습니다",
+                          "errors": []
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "내 여행 또는 장소를 찾을 수 없음",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "NOT_FOUND_USER_TRAVEL",
+                        value = """
+                            {
+                              "code": "TRAVEL-02-002",
+                              "message": "내 여행 정보를 찾을 수 없습니다",
+                              "errors": []
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "NOT_FOUND_PLACE",
+                        value = """
+                            {
+                              "code": "PLACE-02-001",
+                              "message": "장소를 찾을 수 없습니다",
+                              "errors": []
+                            }
+                            """
+                    )
+                }
+            )
+        ),
+        @ApiResponse(
+            responseCode = "422",
+            description = "유효성 검증 실패",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "VALIDATION_ERROR",
+                    value = """
+                        {
+                          "code": "COMM-01-005",
+                          "message": "유효성 검증에 실패하였습니다",
+                          "errors": [
+                            {
+                              "field": "itineraries",
+                              "message": "일정 목록은 최소 1개 이상이어야 합니다."
+                            }
+                          ]
+                        }
+                        """
+                )
+            )
+        )
+    })
+    @PutMapping("/{id}/itinerary")
+    ResponseEntity<SuccessResponse> replaceUserTravelItinerary(
+        @CurrentUuid String uuid,
+        @Parameter(description = "사용자 여행 ID", example = "1", required = true)
+        @PathVariable("id") final Long id,
+        @Valid @RequestBody ReplaceUserTravelItineraryRequest request
     );
 
     @Operation(

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelApi.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelApi.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelPlaceStartTimesRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelContentCardResponse;
@@ -129,6 +130,94 @@ public interface UserTravelApi {
     ResponseEntity<?> createUserTravel(
         @CurrentUuid String uuid,
         @Valid @RequestBody CreateUserTravelRequest request
+    );
+
+    @Operation(
+        summary = "내 여행 수정",
+        description = "사용자 본인의 여행 제목과 날짜를 수정합니다. nights/days는 서버에서 재계산됩니다.",
+        security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "성공",
+            content = @Content(
+                schema = @Schema(implementation = SuccessResponse.class),
+                examples = @ExampleObject(
+                    name = "SUCCESS",
+                    value = """
+                        {
+                          "code": "2000",
+                          "message": "요청에 성공하였습니다.",
+                          "data": {}
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "여행 종료일이 시작일보다 앞설 수 없음",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "INVALID_DATE_ORDER",
+                    value = """
+                        {
+                          "code": "TRAVEL-04-001",
+                          "message": "여행 종료일이 시작일보다 앞설 수 없습니다",
+                          "errors": []
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "내 여행을 찾을 수 없음",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "NOT_FOUND_USER_TRAVEL",
+                    value = """
+                        {
+                          "code": "TRAVEL-02-002",
+                          "message": "내 여행 정보를 찾을 수 없습니다",
+                          "errors": []
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "422",
+            description = "유효성 검증 실패",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "VALIDATION_ERROR",
+                    value = """
+                        {
+                          "code": "COMM-01-005",
+                          "message": "유효성 검증에 실패하였습니다",
+                          "errors": [
+                            {
+                              "field": "title",
+                              "message": "여행 제목은 필수입니다."
+                            }
+                          ]
+                        }
+                        """
+                )
+            )
+        )
+    })
+    @PatchMapping("/{id}")
+    ResponseEntity<SuccessResponse> updateUserTravel(
+        @CurrentUuid String uuid,
+        @Parameter(description = "사용자 여행 ID", example = "1", required = true)
+        @PathVariable("id") final Long id,
+        @Valid @RequestBody UpdateUserTravelRequest request
     );
 
     @Operation(

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelPlaceStartTimesRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelContentCardResponse;
@@ -34,6 +35,17 @@ public class UserTravelController implements UserTravelApi {
     ) {
         Long userTravelId = userTravelFacade.createUserTravel(uuid, request);
         return ResponseEntity.ok(SuccessResponse.success("userTravelId", userTravelId));
+    }
+
+    @Override
+    @PatchMapping("/{id}")
+    public ResponseEntity<SuccessResponse> updateUserTravel(
+        @CurrentUuid String uuid,
+        @PathVariable("id") final Long id,
+        @Valid @RequestBody UpdateUserTravelRequest request
+    ) {
+        userTravelFacade.updateUserTravel(uuid, id, request);
+        return ResponseEntity.ok(SuccessResponse.noContent());
     }
 
     @Override

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserTravelController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.ReplaceUserTravelItineraryRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelPlaceStartTimesRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
@@ -45,6 +46,17 @@ public class UserTravelController implements UserTravelApi {
         @Valid @RequestBody UpdateUserTravelRequest request
     ) {
         userTravelFacade.updateUserTravel(uuid, id, request);
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+
+    @Override
+    @PutMapping("/{id}/itinerary")
+    public ResponseEntity<SuccessResponse> replaceUserTravelItinerary(
+        @CurrentUuid String uuid,
+        @PathVariable("id") final Long id,
+        @Valid @RequestBody ReplaceUserTravelItineraryRequest request
+    ) {
+        userTravelFacade.replaceUserTravelItinerary(uuid, id, request);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/ReplaceUserTravelItineraryRequest.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/ReplaceUserTravelItineraryRequest.java
@@ -16,7 +16,7 @@ public record ReplaceUserTravelItineraryRequest(
 		requiredMode = Schema.RequiredMode.REQUIRED
 	)
 	@NotEmpty(message = "일정 목록은 최소 1개 이상이어야 합니다.")
-	List<@Valid Item> itineraries
+	List<@NotNull(message = "일정 항목은 null일 수 없습니다.") @Valid Item> itineraries
 ) {
 	public record Item(
 		@Schema(description = "장소 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/ReplaceUserTravelItineraryRequest.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/ReplaceUserTravelItineraryRequest.java
@@ -1,0 +1,43 @@
+package com.yapp.ndgl.application.domains.travel.controller.dto;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReplaceUserTravelItineraryRequest(
+	@Schema(
+		description = "전체 일정 목록(최소 1개 이상)",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
+	@NotEmpty(message = "일정 목록은 최소 1개 이상이어야 합니다.")
+	List<@Valid Item> itineraries
+) {
+	public record Item(
+		@Schema(description = "장소 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotNull(message = "placeId는 필수입니다.")
+		Long placeId,
+		@Schema(description = "일차", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotNull(message = "day는 필수입니다.")
+		@Min(value = 1, message = "day는 1 이상이어야 합니다.")
+		Integer day,
+		@Schema(description = "일차 내 순서", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotNull(message = "sequence는 필수입니다.")
+		@Min(value = 1, message = "sequence는 1 이상이어야 합니다.")
+		Integer sequence,
+		@Schema(description = "해당 장소 시작 시간", example = "09:00:00", nullable = true)
+		LocalTime startTime,
+		@Schema(description = "예상 소요 시간(분)", example = "60", nullable = true)
+		@Min(value = 1, message = "estimatedDuration은 1 이상이어야 합니다.")
+		Integer estimatedDuration,
+		@Schema(description = "여행자 팁", example = "오전 시간 방문 추천", nullable = true)
+		@Size(max = 1000, message = "travelerTip은 최대 1000자까지 입력할 수 있습니다.")
+		String travelerTip
+	) {
+	}
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/UpdateUserTravelRequest.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/UpdateUserTravelRequest.java
@@ -1,0 +1,22 @@
+package com.yapp.ndgl.application.domains.travel.controller.dto;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateUserTravelRequest(
+	@Schema(description = "여행 제목", example = "도쿄 3박 4일", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "여행 제목은 필수입니다.")
+	@Size(max = 500, message = "여행 제목은 최대 500자까지 입력할 수 있습니다.")
+	String title,
+	@Schema(description = "여행 시작일", example = "2026-01-23", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "여행 시작일은 필수입니다.")
+	LocalDate startDate,
+	@Schema(description = "여행 종료일", example = "2026-01-27", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "여행 종료일은 필수입니다.")
+	LocalDate endDate
+) {
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserTravelFacade.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserTravelFacade.java
@@ -2,6 +2,7 @@ package com.yapp.ndgl.application.domains.travel.facade;
 
 import com.yapp.ndgl.application.common.annotation.Facade;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.ReplaceUserTravelItineraryRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelPlaceStartTimesRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
@@ -29,6 +30,15 @@ public class UserTravelFacade {
     public void updateUserTravel(final String uuid, final Long userTravelId, final UpdateUserTravelRequest request) {
         log.info("사용자 여행 정보를 수정합니다. uuid = {}, userTravelId = {}", uuid, userTravelId);
         userTravelService.updateUserTravel(uuid, userTravelId, request);
+    }
+
+    public void replaceUserTravelItinerary(
+        final String uuid,
+        final Long userTravelId,
+        final ReplaceUserTravelItineraryRequest request
+    ) {
+        log.info("사용자 여행 일정을 전체 교체합니다. uuid = {}, userTravelId = {}", uuid, userTravelId);
+        userTravelService.replaceUserTravelItinerary(uuid, userTravelId, request);
     }
 
     public void bulkUpdateUserTravelPlaceStartTimes(

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserTravelFacade.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserTravelFacade.java
@@ -3,6 +3,7 @@ package com.yapp.ndgl.application.domains.travel.facade;
 import com.yapp.ndgl.application.common.annotation.Facade;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelPlaceStartTimesRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelContentCardResponse;
@@ -25,11 +26,16 @@ public class UserTravelFacade {
         return userTravelService.createUserTravel(uuid, request);
     }
 
+    public void updateUserTravel(final String uuid, final Long userTravelId, final UpdateUserTravelRequest request) {
+        log.info("사용자 여행 정보를 수정합니다. uuid = {}, userTravelId = {}", uuid, userTravelId);
+        userTravelService.updateUserTravel(uuid, userTravelId, request);
+    }
+
     public void bulkUpdateUserTravelPlaceStartTimes(
         final String uuid, final Long userTravelId,
         final UpdateUserTravelPlaceStartTimesRequest request
     ) {
-        log.info("사용자 여행 장소 startTime을 일괄 수정합니다. uuid = {}, userTravelId = {}, request = {}", uuid, userTravelId, request);
+        log.info("사용자 여행 장소 startTime을 일괄 수정합니다. uuid = {}, userTravelId = {}", uuid, userTravelId);
         userTravelService.bulkUpdateUserTravelPlaceStartTimes(uuid, userTravelId, request);
     }
 

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserTravelService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserTravelService.java
@@ -2,9 +2,12 @@ package com.yapp.ndgl.application.domains.travel.service;
 
 import java.time.temporal.ChronoUnit;
 import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.ReplaceUserTravelItineraryRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelPlaceStartTimesRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelRequest;
@@ -20,6 +24,7 @@ import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTrave
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelContentCardResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelItineraryResponse;
 import com.yapp.ndgl.common.exception.GlobalException;
+import com.yapp.ndgl.common.exception.PlaceErrorCode;
 import com.yapp.ndgl.common.exception.TravelErrorCode;
 import com.yapp.ndgl.common.response.SliceResponse;
 import com.yapp.ndgl.domain.place.Place;
@@ -109,6 +114,35 @@ public class UserTravelService {
 	}
 
 	@Transactional
+	public void replaceUserTravelItinerary(
+		final String uuid,
+		final Long userTravelId,
+		final ReplaceUserTravelItineraryRequest request
+	) {
+		log.info("내 여행 일정을 전체 교체합니다. uuid = {}, userTravelId = {}, itineraryCount = {}",
+			uuid, userTravelId, request.itineraries().size());
+		User user = userDomainService.findByUuid(uuid);
+		UserTravel userTravel = userTravelDomainService.findByIdAndUserId(userTravelId, user.getId());
+
+		validateReplaceUserTravelItineraryRequest(userTravel, request.itineraries());
+
+		List<UserTravelPlace> userTravelPlaces = request.itineraries().stream()
+			.map(itinerary -> UserTravelPlace.create(
+				userTravelId,
+				itinerary.placeId(),
+				itinerary.day(),
+				itinerary.sequence(),
+				itinerary.travelerTip(),
+				itinerary.startTime(),
+				itinerary.estimatedDuration()
+			)).toList();
+
+		userTravelDomainService.replaceUserTravelPlaces(userTravelId, userTravelPlaces);
+		log.info("내 여행 일정을 전체 교체했습니다. uuid = {}, userTravelId = {}, itineraryCount = {}",
+			uuid, userTravelId, userTravelPlaces.size());
+	}
+
+	@Transactional
 	public void bulkUpdateUserTravelPlaceStartTimes(
 		final String uuid, final Long userTravelId, final UpdateUserTravelPlaceStartTimesRequest request
 	) {
@@ -127,6 +161,41 @@ public class UserTravelService {
 			.keySet().stream()
 			.toList();
 		userTravelDomainService.bulkUpdateStartTime(userTravelId, userTravelPlaceIds, startTimeByUserTravelPlaceId);
+	}
+
+	private void validateReplaceUserTravelItineraryRequest(
+		final UserTravel userTravel,
+		final List<ReplaceUserTravelItineraryRequest.Item> itineraries
+	) {
+		Set<Long> placeIds = new HashSet<>();
+		Map<Integer, Set<Integer>> sequencesByDay = new HashMap<>();
+
+		for (ReplaceUserTravelItineraryRequest.Item itinerary : itineraries) {
+			if (itinerary.day() > userTravel.getDays()) {
+				log.warn("내 여행 일정 교체 검증 실패 - 일차 범위 초과. userTravelId = {}, maxDay = {}, requestDay = {}",
+					userTravel.getId(), userTravel.getDays(), itinerary.day());
+				throw new GlobalException(TravelErrorCode.INVALID_ITINERARY_REQUEST);
+			}
+			if (!placeIds.add(itinerary.placeId())) {
+				log.warn("내 여행 일정 교체 검증 실패 - 중복 placeId. userTravelId = {}, placeId = {}",
+					userTravel.getId(), itinerary.placeId());
+				throw new GlobalException(TravelErrorCode.INVALID_ITINERARY_REQUEST);
+			}
+
+			Set<Integer> daySequences = sequencesByDay.computeIfAbsent(itinerary.day(), day -> new HashSet<>());
+			if (!daySequences.add(itinerary.sequence())) {
+				log.warn("내 여행 일정 교체 검증 실패 - 동일 일차 sequence 중복. userTravelId = {}, day = {}, sequence = {}",
+					userTravel.getId(), itinerary.day(), itinerary.sequence());
+				throw new GlobalException(TravelErrorCode.INVALID_ITINERARY_REQUEST);
+			}
+		}
+
+		int foundPlaceCount = placeDomainService.findByIds(placeIds.stream().toList()).size();
+		if (foundPlaceCount != placeIds.size()) {
+			log.warn("내 여행 일정 교체 검증 실패 - 존재하지 않는 placeId 포함. userTravelId = {}, requestedCount = {}, foundCount = {}",
+				userTravel.getId(), placeIds.size(), foundPlaceCount);
+			throw new GlobalException(PlaceErrorCode.NOT_FOUND_PLACE);
+		}
 	}
 
 	@Transactional(readOnly = true)

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserTravelService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserTravelService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelPlaceStartTimesRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UpdateUserTravelRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UpcomingUserTravelListResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelContentCardResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserTravelItineraryResponse;
@@ -35,6 +37,7 @@ import com.yapp.ndgl.domain.user.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class UserTravelService {
 
@@ -70,6 +73,39 @@ public class UserTravelService {
 			nights,
 			days
 		).getId();
+	}
+
+	@Transactional
+	public void updateUserTravel(final String uuid, final Long userTravelId, final UpdateUserTravelRequest request) {
+		log.info("내 여행 정보를 수정합니다. uuid = {}, userTravelId = {}", uuid, userTravelId);
+		User user = userDomainService.findByUuid(uuid);
+		String title = request.title().trim();
+
+		if (request.endDate().isBefore(request.startDate())) {
+			log.warn(
+				"내 여행 정보 수정 실패 - 날짜 순서 오류. uuid = {}, userTravelId = {}, startDate = {}, endDate = {}",
+				uuid,
+				userTravelId,
+				request.startDate(),
+				request.endDate()
+			);
+			throw new GlobalException(TravelErrorCode.INVALID_DATE_ORDER);
+		}
+
+		long daysBetween = ChronoUnit.DAYS.between(request.startDate(), request.endDate());
+		int nights = (int)daysBetween;
+		int days = nights + 1;
+
+		userTravelDomainService.updateUserTravel(
+			userTravelId,
+			user.getId(),
+			title,
+			request.startDate(),
+			request.endDate(),
+			nights,
+			days
+		);
+		log.info("내 여행 정보를 수정했습니다. uuid = {}, userTravelId = {}", uuid, userTravelId);
 	}
 
 	@Transactional

--- a/common/src/main/java/com/yapp/ndgl/common/exception/TravelErrorCode.java
+++ b/common/src/main/java/com/yapp/ndgl/common/exception/TravelErrorCode.java
@@ -20,7 +20,9 @@ public enum TravelErrorCode implements BaseErrorCode {
      * BUSINESS_RULE_VIOLATION
      */
     INVALID_DATE_ORDER(StatusCode.BAD_REQUEST, DomainCode.TRAVEL,
-        CategoryCode.BUSINESS_RULE_VIOLATION, "001", "여행 종료일이 시작일보다 앞설 수 없습니다");
+        CategoryCode.BUSINESS_RULE_VIOLATION, "001", "여행 종료일이 시작일보다 앞설 수 없습니다"),
+    INVALID_ITINERARY_REQUEST(StatusCode.BAD_REQUEST, DomainCode.TRAVEL,
+        CategoryCode.BUSINESS_RULE_VIOLATION, "002", "여행 일정 요청 값이 올바르지 않습니다");
 
     private final StatusCode statusCode;
     private final DomainCode domainCode;

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/entity/UserTravelEntity.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/entity/UserTravelEntity.java
@@ -73,4 +73,18 @@ public class UserTravelEntity extends BaseEntity {
         this.nights = nights;
         this.days = days;
     }
+
+    public void updateTravelInfo(
+        final String title,
+        final LocalDate startDate,
+        final LocalDate endDate,
+        final int nights,
+        final int days
+    ) {
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.nights = nights;
+        this.days = days;
+    }
 }

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserTravelPlaceRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserTravelPlaceRepository.java
@@ -12,4 +12,6 @@ public interface UserTravelPlaceRepository extends JpaRepository<UserTravelPlace
     List<UserTravelPlaceEntity> findByUserTravelIdAndDayOrderBySequenceAsc(Long userTravelId, Integer day);
 
     List<UserTravelPlaceEntity> findByIdIn(List<Long> ids);
+
+    void deleteByUserTravelId(Long userTravelId);
 }

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserTravelDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserTravelDomainService.java
@@ -107,6 +107,22 @@ public class UserTravelDomainService {
 			.orElseThrow(() -> new GlobalException(TravelErrorCode.NOT_FOUND_USER_TRAVEL));
 	}
 
+	@Transactional
+	public void updateUserTravel(
+		final Long userTravelId,
+		final Long userId,
+		final String title,
+		final LocalDate startDate,
+		final LocalDate endDate,
+		final int nights,
+		final int days
+	) {
+		UserTravelEntity userTravelEntity = userTravelRepository.findByIdAndUserId(userTravelId, userId)
+			.orElseThrow(() -> new GlobalException(TravelErrorCode.NOT_FOUND_USER_TRAVEL));
+		userTravelEntity.updateTravelInfo(title, startDate, endDate, nights, days);
+		userTravelRepository.save(userTravelEntity);
+	}
+
 	@Transactional(readOnly = true)
 	public List<UserTravelPlace> findPlacesByUserTravelIdAndDay(final Long userTravelId, final int day) {
 		List<UserTravelPlaceEntity> placeEntities =
@@ -140,7 +156,6 @@ public class UserTravelDomainService {
 
 		for (UserTravelPlaceEntity placeEntity : placeEntities) {
 			placeEntity.updateStartTime(startTimeByUserTravelPlaceId.get(placeEntity.getId()));
-			userTravelPlaceRepository.save(placeEntity);
 		}
 	}
 

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserTravelDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserTravelDomainService.java
@@ -120,7 +120,19 @@ public class UserTravelDomainService {
 		UserTravelEntity userTravelEntity = userTravelRepository.findByIdAndUserId(userTravelId, userId)
 			.orElseThrow(() -> new GlobalException(TravelErrorCode.NOT_FOUND_USER_TRAVEL));
 		userTravelEntity.updateTravelInfo(title, startDate, endDate, nights, days);
-		userTravelRepository.save(userTravelEntity);
+	}
+
+	@Transactional
+	public void replaceUserTravelPlaces(final Long userTravelId, final List<UserTravelPlace> userTravelPlaces) {
+		userTravelPlaceRepository.deleteByUserTravelId(userTravelId);
+		if (userTravelPlaces.isEmpty()) {
+			return;
+		}
+
+		List<UserTravelPlaceEntity> entities = userTravelPlaces.stream()
+			.map(UserTravelPlaceMapper::toEntity)
+			.toList();
+		userTravelPlaceRepository.saveAll(entities);
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
> 🤖 **이 PR은 OpenAI GPT-5-mini를 사용하여 자동 생성되었습니다.**

## 요약
내 여행 관련 API의 기능 확장 및 내부 도메인/레포지토리 보강을 통해 여행 정보 수정과 일정 전체 교체 기능을 추가했습니다. (요약 통계: 10 files changed, 449 insertions(+), 3 deletions(-))

## 주요 변경 사항
### 1. 내 여행 정보 수정 (PATCH /{id})
- 사용자 본인의 여행 제목, 시작일, 종료일을 수정하는 API 추가.
- 서버에서 nights/days를 재계산하여 도메인에 반영.
- 날짜 검증: 종료일이 시작일보다 이전이면 예외(TravelErrorCode.INVALID_DATE_ORDER) 발생.
- 로그 추가로 요청/완료 흐름 추적 가능.

### 2. 여행 일정 전체 교체 (PUT /{id}/itinerary)
- 사용자가 전달한 전체 일정 목록으로 기존 일정을 전부 교체하는 API 추가.
- 입력 검증:
  - 일차(day)가 여행의 총 일수 범위를 초과하지 않는지 검사.
  - 동일 placeId 중복 금지.
  - 동일 일차 내에서 sequence 중복 금지.
  - 요청에 포함된 placeId들이 실제로 존재하는지 확인(존재하지 않으면 PlaceErrorCode.NOT_FOUND_PLACE).
- 도메인 처리: 기존 장소들을 삭제한 뒤 요청 목록을 전부 저장(원자적 교체, 트랜잭션 안에서 수행).
- 대량 저장으로 성능 및 일관성 확보.

### 3. DTO 및 입력 검증 추가
- UpdateUserTravelRequest: title, startDate, endDate 필드 및 validation 추가.
- ReplaceUserTravelItineraryRequest: 최소 1개 이상의 itinerary 항목(required), 각 항목에 대한 상세 validation(정수 범위, 문자열 길이 등).
- DTO 레벨에서 가능한 유효성 검사를 선언적으로 처리하여 컨트롤러 진입 전 검증 수행.

### 4. 도메인/레포지토리 변경 및 페이스라인 연계
- UserTravelEntity에 여행 정보 일괄 갱신을 위한 updateTravelInfo 메서드 추가.
- UserTravelPlaceRepository에 deleteByUserTravelId 추가(전체 교체 시 기존 레코드 삭제).
- UserTravelDomainService에 updateUserTravel, replaceUserTravelPlaces 구현 추가(트랜잭션 경계 내에서 변경).
- Facade 계층에 대응 메서드 추가로 애플리케이션 계층 호출 루트 정리.
- 서비스 계층에서 검증 로직과 DTO → 도메인 엔티티 매핑 수행.

### 5. 에러 코드 및 로깅
- TravelErrorCode에 INVALID_ITINERARY_REQUEST 항목 추가.
- Service/Facade 전반에 로깅(SLF4J) 추가로 운영 시 추적성 개선.

## 상세 구현 내용
### 새 기술/라이브러리
- 특이사항 없음 (외부 라이브러리 신규 도입 없음). 기존 스택(jakarta.validation, Spring transaction, Lombok 등) 사용.

### 아키텍처/구조 변경
- 책임 분리: 컨트롤러(요청 파싱/검증) → facade(응집된 유스케이스 호출) → service(비즈니스 로직/검증·변환) → domain service(영속성 연산) 흐름을 명확히 유지.
- 일정 전체 교체는 기존 레코드 삭제 후 새로 저장하는 전략을 선택:
  - 이유: 항목 추가/삭제/순서 변경 등을 일괄적으로 처리하기 위한 단순하고 원자적인 접근.
  - 트랜잭션 내에서 수행되어 중간 상태 노출 방지.
  - 대안(개별 비교 후 업데이트)은 복잡도와 버그 위험 증가로 채택하지 않음.

### 복잡한 로직
- 일정 교체 입력 검증(요약):
  - 중복 placeId 체크: HashSet 사용
  - 일차별 sequence 중복 체크: Map<Integer, Set<Integer>> (day → sequence 집합)
  - day 범위 검증: 요청 day <= userTravel.getDays()
  - place 존재 여부 검증: placeDomainService.findByIds(...) 호출 후 개수 비교
- 날짜 재계산 로직:
  - ChronoUnit.DAYS.between(startDate, endDate)를 이용해 nights 계산(nights = daysBetween), days = nights + 1
  - endDate 이전 검사 후 예외 처리
- 예시(요청 바디 예시)


### 기술적 결정(선택 배경)
- 전체 교체 전략 채택 이유:
  - 일정 간 재정렬/중복 제거 등 복잡한 변환을 단순화하고, 일관성 보장(트랜잭션)과 구현 복잡도 감소를 우선시함.
- validateReplaceUserTravelItineraryRequest는 서비스 레벨에서 수행:
  - DTO 검증으로 커버되지 않는 도메인 제약(여행의 days 범위, 존재하는 place 여부, cross-field 제약)을 처리하기 위함.
- bulk 저장(saveAll) 사용으로 DB round-trip 최소화 및 성능 개선.

### 필요 설정
- 특이사항 없음(추가 환경변수/시크릿 불필요).

## 트러블 슈팅
- 날짜 순서 검증 문제: 사용자가 endDate < startDate를 보내는 경우를 방지하기 위해 서비스 레벨에서 명시적 검사 후 TravelErrorCode.INVALID_DATE_ORDER로 예외 처리하고 로그로 원인 기록.
- 일정 교체 시 중복 데이터/비존재 장소로 인한 실패를 예방하기 위해 다중 검증(중복 placeId, 일차별 sequence 중복, 존재 여부) 로직을 추가함.
- 전체 교체 구현 중 기존 저장 방식(개별 save 루프)이 성능/일관성 문제 소지가 있어 deleteByUserTravelId + saveAll 방식으로 변경.
- 트랜잭션 경계 설정: replace/update 작업은 모두 @Transactional로 설정하여 부분 반영 상황을 방지함.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 여행 정보(제목, 시작일, 종료일) 수정 기능 추가
  * 여행 일정 전체 교체 기능 추가
  * 여행 일정 요청값 검증 강화로 데이터 유효성 보증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->