### PR TITLE
Feature/NDGL-92 장소 즐겨찾기 목록 조회 API

### DIFF
--- a/application/src/main/java/com/yapp/ndgl/application/domains/place/api/PlaceApi.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/place/api/PlaceApi.java
@@ -10,8 +10,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
 import com.yapp.ndgl.application.domains.place.controller.request.SearchPlaceRequest;
 import com.yapp.ndgl.application.domains.place.controller.response.PlaceDetailResponse;
+import com.yapp.ndgl.application.domains.place.controller.response.PlaceFavoriteListResponse;
 import com.yapp.ndgl.application.domains.place.controller.response.PlacePhotoResponse;
 import com.yapp.ndgl.common.response.ErrorResponse;
+import com.yapp.ndgl.common.response.SliceResponse;
 import com.yapp.ndgl.common.response.SuccessResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -423,6 +425,55 @@ public interface PlaceApi {
 	ResponseEntity<?> readPlacePhotos(
 		@Parameter(description = "Google Places 장소 ID", example = "ChIJSc8jdZORQTURu6BMwxrKbGg", required = true)
 		@RequestParam("googlePlaceId") final String googlePlaceId
+	);
+
+	@Operation(
+		summary = "장소 즐겨찾기 목록 조회",
+		description = "사용자 본인의 장소 즐겨찾기 목록을 조회합니다.",
+		security = @SecurityRequirement(name = "bearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "성공",
+			content = @Content(
+				schema = @Schema(implementation = PlaceFavoriteListResponse.class),
+				examples = @ExampleObject(
+					name = "SUCCESS",
+					value = """
+						{
+						  "code": "2000",
+						  "message": "요청에 성공하였습니다.",
+						  "data": {
+						    "content": [
+						      {
+						        "id": 1,
+						        "googlePlaceId": "ChIJSc8jdZORQTURu6BMwxrKbGg",
+						        "formattedAddress": "일본 도쿄 신주쿠 ...",
+						        "latitude": 35.6946268,
+						        "longitude": 139.7016497,
+						        "rating": 4.9,
+						        "userRatingCount": 7306,
+						        "name": "규카츠 모토무라 신주쿠 본점",
+						        "thumbnail": "https://example.com/thumbnail.jpg",
+						        "category": "RESTAURANT"
+						      }
+						    ],
+						    "hasNext": true
+						  }
+						}
+						"""
+				)
+			)
+		)
+	})
+	@GetMapping("/favorite")
+	ResponseEntity<SuccessResponse<SliceResponse<PlaceFavoriteListResponse>>> readFavoritePlaces(
+		@CurrentUuid String uuid,
+		@Parameter(description = "페이지 번호 (0부터 시작)", example = "0", required = false)
+		@RequestParam(value = "page", defaultValue = "0") @Min(value = 0, message = "page는 0 이상 입니다.") final int page,
+		@Parameter(description = "페이지 사이즈", example = "20", required = false)
+		@RequestParam(value = "size", defaultValue = "20") @Min(value = 1, message = "size는 1 이상 입니다.") final int size
 	);
 
 	@Operation(

--- a/application/src/main/java/com/yapp/ndgl/application/domains/place/controller/PlaceController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/place/controller/PlaceController.java
@@ -14,10 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 import com.yapp.ndgl.application.domains.place.api.PlaceApi;
 import com.yapp.ndgl.application.domains.place.controller.request.SearchPlaceRequest;
 import com.yapp.ndgl.application.domains.place.controller.response.PlaceDetailResponse;
+import com.yapp.ndgl.application.domains.place.controller.response.PlaceFavoriteListResponse;
 import com.yapp.ndgl.application.domains.place.controller.response.PlacePhotoResponse;
 import com.yapp.ndgl.application.domains.place.facade.PlaceDetailFacade;
 import com.yapp.ndgl.application.domains.place.facade.PlaceFavoriteFacade;
 import com.yapp.ndgl.application.domains.place.facade.PlacePhotoFacade;
+import com.yapp.ndgl.common.response.SliceResponse;
 import com.yapp.ndgl.common.response.SuccessResponse;
 
 import jakarta.validation.Valid;
@@ -60,6 +62,17 @@ public class PlaceController implements PlaceApi {
 		final @RequestParam("googlePlaceId") String googlePlaceId
 	) {
 		PlacePhotoResponse response = placePhotoFacade.readPlacePhotos(googlePlaceId);
+		return ResponseEntity.ok(SuccessResponse.success(response));
+	}
+
+	@Override
+	@GetMapping("/favorite")
+	public ResponseEntity<SuccessResponse<SliceResponse<PlaceFavoriteListResponse>>> readFavoritePlaces(
+		@CurrentUuid String uuid,
+		@RequestParam(value = "page", defaultValue = "0") final int page,
+		@RequestParam(value = "size", defaultValue = "20") final int size
+	) {
+		SliceResponse<PlaceFavoriteListResponse> response = placeFavoriteFacade.readFavoritePlaces(uuid, page, size);
 		return ResponseEntity.ok(SuccessResponse.success(response));
 	}
 

--- a/application/src/main/java/com/yapp/ndgl/application/domains/place/controller/response/PlaceFavoriteListResponse.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/place/controller/response/PlaceFavoriteListResponse.java
@@ -1,0 +1,44 @@
+package com.yapp.ndgl.application.domains.place.controller.response;
+
+import com.yapp.ndgl.common.type.PlaceCategory;
+import com.yapp.ndgl.domain.place.Place;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PlaceFavoriteListResponse(
+    @Schema(description = "장소 PK", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    Long id,
+    @Schema(description = "Google Places 장소 ID", example = "ChIJSc8jdZORQTURu6BMwxrKbGg", requiredMode = Schema.RequiredMode.REQUIRED)
+    String googlePlaceId,
+    @Schema(description = "주소", example = "일본 〒160-0021 Tokyo, Shinjuku City, Kabukichō, ...", nullable = true)
+    String formattedAddress,
+    @Schema(description = "위도", example = "35.6946268", requiredMode = Schema.RequiredMode.REQUIRED)
+    Double latitude,
+    @Schema(description = "경도", example = "139.7016497", requiredMode = Schema.RequiredMode.REQUIRED)
+    Double longitude,
+    @Schema(description = "평점", example = "4.9", nullable = true)
+    Double rating,
+    @Schema(description = "사용자 평점 수", example = "7306", nullable = true)
+    Integer userRatingCount,
+    @Schema(description = "장소명", example = "규카츠 모토무라 신주쿠 본점", requiredMode = Schema.RequiredMode.REQUIRED)
+    String name,
+    @Schema(description = "썸네일 이미지 URL", example = "https://example.com/thumbnail.jpg", nullable = true)
+    String thumbnail,
+    @Schema(description = "장소 카테고리", example = "RESTAURANT", requiredMode = Schema.RequiredMode.REQUIRED)
+    PlaceCategory category
+) {
+
+    public static PlaceFavoriteListResponse from(final Place place) {
+        return new PlaceFavoriteListResponse(
+            place.getId(),
+            place.getGooglePlaceId(),
+            place.getFormattedAddress(),
+            place.getLatitude(),
+            place.getLongitude(),
+            place.getRating(),
+            place.getUserRatingCount(),
+            place.getName(),
+            place.getThumbnail(),
+            place.getCategory()
+        );
+    }
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/place/facade/PlaceFavoriteFacade.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/place/facade/PlaceFavoriteFacade.java
@@ -1,7 +1,9 @@
 package com.yapp.ndgl.application.domains.place.facade;
 
 import com.yapp.ndgl.application.common.annotation.Facade;
+import com.yapp.ndgl.application.domains.place.controller.response.PlaceFavoriteListResponse;
 import com.yapp.ndgl.application.domains.place.service.PlaceFavoriteService;
+import com.yapp.ndgl.common.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,5 +22,12 @@ public class PlaceFavoriteFacade {
     public void removeFavoritePlace(final String uuid, final String googlePlaceId) {
         log.info("장소 즐겨찾기를 삭제합니다. uuid = {}, googlePlaceId = {}", uuid, googlePlaceId);
         placeFavoriteService.removeFavoritePlace(uuid, googlePlaceId);
+    }
+
+    public SliceResponse<PlaceFavoriteListResponse> readFavoritePlaces(
+        final String uuid, final int page, final int size
+    ) {
+        log.info("즐겨찾기 장소 목록을 조회합니다. uuid = {}, page = {}, size = {}", uuid, page, size);
+        return placeFavoriteService.readFavoritePlaces(uuid, page, size);
     }
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/place/service/PlaceFavoriteService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/place/service/PlaceFavoriteService.java
@@ -1,5 +1,7 @@
 package com.yapp.ndgl.application.domains.place.service;
 
+import com.yapp.ndgl.application.domains.place.controller.response.PlaceFavoriteListResponse;
+import com.yapp.ndgl.common.response.SliceResponse;
 import com.yapp.ndgl.domain.place.Place;
 import com.yapp.ndgl.domain.place.service.PlaceDomainService;
 import com.yapp.ndgl.domain.place.service.UserFavoritePlaceDomainService;
@@ -29,5 +31,19 @@ public class PlaceFavoriteService {
         User user = userDomainService.findByUuid(uuid);
         Place place = placeDomainService.readPlaceDetailByGooglePLaceId(googlePlaceId);
         userFavoritePlaceDomainService.removeFavoritePlace(user.getId(), place.getId());
+    }
+
+    @Transactional(readOnly = true)
+    public SliceResponse<PlaceFavoriteListResponse> readFavoritePlaces(final String uuid, final int page, final int size) {
+        User user = userDomainService.findByUuid(uuid);
+        SliceResponse<Place> favoritePlaces = userFavoritePlaceDomainService.findFavoritePlacesByUserId(
+            user.getId(), page, size
+        );
+        return SliceResponse.of(
+            favoritePlaces.getContent().stream()
+                .map(PlaceFavoriteListResponse::from)
+                .toList(),
+            favoritePlaces.isHasNext()
+        );
     }
 }

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/place/repository/UserFavoritePlaceRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/place/repository/UserFavoritePlaceRepository.java
@@ -3,7 +3,7 @@ package com.yapp.ndgl.domain.place.repository;
 import com.yapp.ndgl.domain.place.entity.UserFavoritePlaceEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserFavoritePlaceRepository extends JpaRepository<UserFavoritePlaceEntity, Long> {
+public interface UserFavoritePlaceRepository extends JpaRepository<UserFavoritePlaceEntity, Long>, UserFavoritePlaceRepositoryCustom {
 
     boolean existsByUserIdAndPlaceId(Long userId, Long placeId);
 

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/place/repository/UserFavoritePlaceRepositoryCustom.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/place/repository/UserFavoritePlaceRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.yapp.ndgl.domain.place.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import com.yapp.ndgl.domain.place.entity.PlaceEntity;
+
+public interface UserFavoritePlaceRepositoryCustom {
+
+    List<PlaceEntity> findFavoritePlacesByUserId(Long userId, Pageable pageable);
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/place/repository/UserFavoritePlaceRepositoryImpl.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/place/repository/UserFavoritePlaceRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.yapp.ndgl.domain.place.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yapp.ndgl.domain.place.entity.PlaceEntity;
+import com.yapp.ndgl.domain.place.entity.QPlaceEntity;
+import com.yapp.ndgl.domain.place.entity.QUserFavoritePlaceEntity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserFavoritePlaceRepositoryImpl implements UserFavoritePlaceRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PlaceEntity> findFavoritePlacesByUserId(final Long userId, final Pageable pageable) {
+        QUserFavoritePlaceEntity userFavoritePlace = QUserFavoritePlaceEntity.userFavoritePlaceEntity;
+        QPlaceEntity place = QPlaceEntity.placeEntity;
+
+        return queryFactory
+            .select(place)
+            .from(userFavoritePlace)
+            .join(place).on(place.id.eq(userFavoritePlace.placeId))
+            .where(userFavoritePlace.userId.eq(userId))
+            .orderBy(userFavoritePlace.id.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/place/service/UserFavoritePlaceDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/place/service/UserFavoritePlaceDomainService.java
@@ -1,11 +1,17 @@
 package com.yapp.ndgl.domain.place.service;
 
+import com.yapp.ndgl.common.response.SliceResponse;
+import com.yapp.ndgl.domain.place.Place;
 import com.yapp.ndgl.domain.place.entity.UserFavoritePlaceEntity;
+import com.yapp.ndgl.domain.place.mapper.PlaceMapper;
 import com.yapp.ndgl.domain.place.repository.UserFavoritePlaceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -32,5 +38,20 @@ public class UserFavoritePlaceDomainService {
     @Transactional
     public void removeFavoritePlace(final Long userId, final Long placeId) {
         userFavoritePlaceRepository.deleteByUserIdAndPlaceId(userId, placeId);
+    }
+
+    @Transactional(readOnly = true)
+    public SliceResponse<Place> findFavoritePlacesByUserId(final Long userId, final int page, final int size) {
+        Pageable pageable = PageRequest.of(page, size + 1);
+        List<Place> favoritePlaces = userFavoritePlaceRepository.findFavoritePlacesByUserId(userId, pageable).stream()
+            .map(PlaceMapper::toDomain)
+            .toList();
+
+        boolean hasNext = favoritePlaces.size() > size;
+        List<Place> content = favoritePlaces.stream()
+            .limit(size)
+            .toList();
+
+        return SliceResponse.of(content, hasNext);
     }
 }


### PR DESCRIPTION
🤖 **이 PR은 AI를 사용하여 자동 생성되었습니다.**

## 요약
사용자 본인의 장소 즐겨찾기 목록 조회 기능을 페이징(Slice) 형태로 추가합니다. 관련 API 문서화와 응답 DTO, 도메인/레포지토리 연동을 포함합니다.

## 변경 내용
- 장소 즐겨찾기 목록 조회 API를 추가
- PlaceFavoriteListResponse 응답 DTO를 추가
- 페이징(Slice) 지원을 포함한 즐겨찾기 조회 서비스 및 퍼사드 로직을 추가
- 사용자 즐겨찾기 레포지토리에 커스텀 쿼리와 구현체를 추가
- UserFavoritePlaceRepository에 existsByUserIdAndPlaceId 메서드를 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자의 즐겨찾기 장소를 조회하는 API 엔드포인트 추가
  * 페이지네이션 지원으로 효율적인 데이터 로딩 구현
  * 즐겨찾기 장소의 상세 정보(주소, 위치, 평점, 썸네일, 카테고리 등) 조회 가능
<!-- end of auto-generated comment: release notes by coderabbit.ai -->