### PR TITLE
Fix/NDGL-117 내 여행 일정 일괄 수정 API Request ID 변경

### DIFF
--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/ReplaceUserTravelItineraryRequest.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/ReplaceUserTravelItineraryRequest.java
@@ -5,10 +5,7 @@ import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 public record ReplaceUserTravelItineraryRequest(
 	@Schema(
@@ -20,9 +17,9 @@ public record ReplaceUserTravelItineraryRequest(
 ) {
 	@Schema(name = "ItineraryItem")
 	public record Item(
-		@Schema(description = "장소 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-		@NotNull(message = "placeId는 필수입니다.")
-		Long placeId,
+		@Schema(description = "Google Place ID", example = "ChIJN1t_tDeuEmsRUsoyG83frY4", requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotBlank(message = "googlePlaceId는 필수입니다.")
+		String googlePlaceId,
 		@Schema(description = "일차", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		@NotNull(message = "day는 필수입니다.")
 		@Min(value = 1, message = "day는 1 이상이어야 합니다.")

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserTravelService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserTravelService.java
@@ -129,12 +129,13 @@ public class UserTravelService {
 		User user = userDomainService.findByUuid(uuid);
 		UserTravel userTravel = userTravelDomainService.findByIdAndUserId(userTravelId, user.getId());
 
-		validateReplaceUserTravelItineraryRequest(userTravel, request.itineraries());
+		Map<String, Long> placeIdByGooglePlaceId =
+			validateAndResolveReplaceUserTravelItineraryRequest(userTravel, request.itineraries());
 
 		List<UserTravelPlace> userTravelPlaces = request.itineraries().stream()
 			.map(itinerary -> UserTravelPlace.create(
 				userTravelId,
-				itinerary.placeId(),
+				placeIdByGooglePlaceId.get(itinerary.googlePlaceId()),
 				itinerary.day(),
 				itinerary.sequence(),
 				itinerary.travelerTip(),
@@ -187,11 +188,11 @@ public class UserTravelService {
 			uuid, userTravelId, userTravelPlaceId);
 	}
 
-	private void validateReplaceUserTravelItineraryRequest(
+	private Map<String, Long> validateAndResolveReplaceUserTravelItineraryRequest(
 		final UserTravel userTravel,
 		final List<ReplaceUserTravelItineraryRequest.Item> itineraries
 	) {
-		Set<Long> placeIds = new HashSet<>();
+		Set<String> googlePlaceIds = new HashSet<>();
 		Map<Integer, Set<Integer>> sequencesByDay = new HashMap<>();
 
 		for (ReplaceUserTravelItineraryRequest.Item itinerary : itineraries) {
@@ -200,11 +201,7 @@ public class UserTravelService {
 					userTravel.getId(), userTravel.getDays(), itinerary.day());
 				throw new GlobalException(TravelErrorCode.INVALID_ITINERARY_REQUEST);
 			}
-			if (!placeIds.add(itinerary.placeId())) {
-				log.warn("내 여행 일정 교체 검증 실패 - 중복 placeId. userTravelId = {}, placeId = {}",
-					userTravel.getId(), itinerary.placeId());
-				throw new GlobalException(TravelErrorCode.INVALID_ITINERARY_REQUEST);
-			}
+			googlePlaceIds.add(itinerary.googlePlaceId());
 
 			Set<Integer> daySequences = sequencesByDay.computeIfAbsent(itinerary.day(), day -> new HashSet<>());
 			if (!daySequences.add(itinerary.sequence())) {
@@ -214,12 +211,15 @@ public class UserTravelService {
 			}
 		}
 
-		int foundPlaceCount = placeDomainService.findByIds(placeIds.stream().toList()).size();
-		if (foundPlaceCount != placeIds.size()) {
-			log.warn("내 여행 일정 교체 검증 실패 - 존재하지 않는 placeId 포함. userTravelId = {}, requestedCount = {}, foundCount = {}",
-				userTravel.getId(), placeIds.size(), foundPlaceCount);
+		List<Place> places = placeDomainService.findByGooglePlaceIds(googlePlaceIds.stream().toList());
+		if (places.size() != googlePlaceIds.size()) {
+			log.warn("내 여행 일정 교체 검증 실패 - 존재하지 않는 googlePlaceId 포함. userTravelId = {}, requestedCount = {}, foundCount = {}",
+				userTravel.getId(), googlePlaceIds.size(), places.size());
 			throw new GlobalException(PlaceErrorCode.NOT_FOUND_PLACE);
 		}
+
+		return places.stream()
+			.collect(Collectors.toMap(Place::getGooglePlaceId, Place::getId));
 	}
 
 	@Transactional(readOnly = true)

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/place/repository/PlaceRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/place/repository/PlaceRepository.java
@@ -1,5 +1,6 @@
 package com.yapp.ndgl.domain.place.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,8 @@ import com.yapp.ndgl.domain.place.entity.PlaceEntity;
 public interface PlaceRepository extends JpaRepository<PlaceEntity, Long> {
 
 	Optional<PlaceEntity> findByGooglePlaceId(final String googlePlaceId);
+
+	List<PlaceEntity> findByGooglePlaceIdIn(final List<String> googlePlaceIds);
 
 	boolean existsByGooglePlaceId(final String googlePlaceId);
 

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/place/service/PlaceDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/place/service/PlaceDomainService.java
@@ -52,6 +52,15 @@ public class PlaceDomainService {
 			.toList();
 	}
 
+	public List<Place> findByGooglePlaceIds(final List<String> googlePlaceIds) {
+		if (googlePlaceIds == null || googlePlaceIds.isEmpty()) {
+			return List.of();
+		}
+		return placeRepository.findByGooglePlaceIdIn(googlePlaceIds).stream()
+			.map(PlaceMapper::toDomain)
+			.toList();
+	}
+
 	public Place findById(final Long id) {
 		if (id == null) {
 			return null;


### PR DESCRIPTION
> 🤖 **이 PR은 AI를 사용하여 자동 생성되었습니다.**

## 요약
여행 일정 교체 API가 클라이언트에서 내부 placeId 대신 Google Place ID(googlePlaceId)를 받도록 변경되었습니다. 서버에서 googlePlaceId 유효성 검증 후 실제 placeId로 해석하여 처리합니다.

## 변경 내용
- 요청 DTO에서 placeId를 제거
- 요청 DTO에 googlePlaceId를 추가
- UserTravelService의 검증을 googlePlaceId 기준으로 변경
- UserTravelService에 googlePlaceId→placeId 매핑 반환 로직을 추가
- 저장소/도메인 레이어에 googlePlaceId 목록 조회 API를 추가

## 참고 사항
클라이언트는 placeId 대신 googlePlaceId로 요청을 보내도록 변경이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 여행 일정에서 Google Place ID를 기반으로 위치를 식별하는 기능 추가
  * 여러 장소를 한 번에 조회하는 배치 검색 기능 강화
  * 위치 검증 로직 개선으로 더욱 안정적인 여행 계획 관리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->