### PR TITLE
feat: [NDGL-132] 사용자 컨텐츠 저장 API, 컨텐츠 구독 API

### DIFF
--- a/application/src/main/java/com/yapp/ndgl/application/common/exception/ApiExceptionHandler.java
+++ b/application/src/main/java/com/yapp/ndgl/application/common/exception/ApiExceptionHandler.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -149,6 +150,24 @@ public class ApiExceptionHandler {
 		return ResponseEntity
 			.status(HttpStatus.UNPROCESSABLE_ENTITY)
 			.body(ErrorResponse.error(errorCode, errors));
+	}
+
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity<ErrorResponse<?>> handleDataIntegrityViolationException(
+		final DataIntegrityViolationException e) {
+		String rootCauseMessage = e.getMostSpecificCause().getMessage();
+		if (rootCauseMessage != null && rootCauseMessage.toLowerCase().contains("duplicate")) {
+			BaseErrorCode errorCode = CommonErrorCode.DATA_INTEGRITY_VIOLATION;
+			logByErrorCode(errorCode, "유니크 제약 조건 위반 (race condition)", e, null);
+			return ResponseEntity
+				.status(HttpStatus.CONFLICT)
+				.body(ErrorResponse.error(errorCode));
+		}
+		BaseErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+		logByErrorCode(errorCode, "예상치 못한 데이터 무결성 위반", e, null);
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ErrorResponse.error(errorCode));
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/application/src/main/java/com/yapp/ndgl/application/common/exception/ApiExceptionHandler.java
+++ b/application/src/main/java/com/yapp/ndgl/application/common/exception/ApiExceptionHandler.java
@@ -155,8 +155,9 @@ public class ApiExceptionHandler {
 	@ExceptionHandler(DataIntegrityViolationException.class)
 	public ResponseEntity<ErrorResponse<?>> handleDataIntegrityViolationException(
 		final DataIntegrityViolationException e) {
-		String rootCauseMessage = e.getMostSpecificCause().getMessage();
-		if (rootCauseMessage != null && rootCauseMessage.toLowerCase().contains("duplicate")) {
+		Throwable cause = e.getCause();
+		if (cause != null && cause.getClass().getName()
+			.equals("org.hibernate.exception.ConstraintViolationException")) {
 			BaseErrorCode errorCode = CommonErrorCode.DATA_INTEGRITY_VIOLATION;
 			logByErrorCode(errorCode, "유니크 제약 조건 위반 (race condition)", e, null);
 			return ResponseEntity

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateApi.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateApi.java
@@ -1,6 +1,7 @@
 package com.yapp.ndgl.application.domains.travel.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
@@ -135,5 +136,105 @@ public interface UserSuggestedTemplateApi {
     ResponseEntity<SuccessResponse<?>> createUserSuggestedTemplate(
         @CurrentUuid String uuid,
         @RequestBody @Valid final CreateUserSuggestedTemplateRequest request
+    );
+
+    @Operation(
+        summary = "게시 알림 구독",
+        description = """
+            다른 사용자가 이미 요청한 영상(TRAVEL-03-003)에 대해 게시 알림을 신청합니다.
+            영상이 ACCEPTED 처리되면 구독자 전체에게 FCM 알림이 발송됩니다.
+            PENDING 상태인 영상에만 구독 신청이 가능합니다. ACCEPTED/DENIED 상태이면 400을 반환합니다.
+            """,
+        security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "구독 성공",
+            content = @Content(
+                examples = @ExampleObject(
+                    name = "SUCCESS",
+                    value = """
+                        {
+                          "code": "2000",
+                          "message": "요청에 성공하였습니다.",
+                          "data": {}
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "UNAUTHORIZED",
+                    value = """
+                        {
+                          "code": "COMM-03-001",
+                          "message": "인증이 필요합니다",
+                          "errors": []
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "PENDING 상태가 아닌 영상 (ACCEPTED 또는 DENIED)",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "NOT_SUBSCRIBABLE_SUGGESTED_TEMPLATE",
+                    value = """
+                        {
+                          "code": "TRAVEL-04-004",
+                          "message": "이미 처리된 영상은 구독할 수 없습니다",
+                          "errors": []
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않는 제안 템플릿",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "NOT_FOUND_SUGGESTED_TEMPLATE",
+                    value = """
+                        {
+                          "code": "TRAVEL-02-003",
+                          "message": "요청된 여행 템플릿을 찾을 수 없습니다",
+                          "errors": []
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "이미 구독 중",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "ALREADY_SUBSCRIBED_SUGGESTED_TEMPLATE",
+                    value = """
+                        {
+                          "code": "TRAVEL-03-005",
+                          "message": "이미 알림 신청한 영상입니다",
+                          "errors": []
+                        }
+                        """
+                )
+            )
+        )
+    })
+    ResponseEntity<SuccessResponse<?>> subscribe(
+        @PathVariable("id") Long templateId,
+        @CurrentUuid String uuid
     );
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateApi.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateApi.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
-import com.yapp.ndgl.application.domains.travel.controller.dto.UserSuggestedTemplateResponse;
 import com.yapp.ndgl.common.response.ErrorResponse;
 import com.yapp.ndgl.common.response.SuccessResponse;
 
@@ -24,7 +23,11 @@ public interface UserSuggestedTemplateApi {
 
     @Operation(
         summary = "여행 템플릿 제안 등록",
-        description = "사용자가 YouTube 영상 링크와 추천 이유를 입력하여 여행 템플릿을 제안합니다. 등록 시 상태는 PENDING으로 설정되며, 영상 URL 형식 유효성만 검증합니다.",
+        description = """
+            사용자가 YouTube 영상 링크와 추천 이유를 입력하여 여행 템플릿을 제안합니다.
+            등록 시 상태는 PENDING으로 설정되며, 영상 URL 형식 유효성만 검증합니다.
+            등록에 성공하면 요청자는 자동으로 해당 템플릿의 구독자로 등록됩니다.
+            """,
         security = @SecurityRequirement(name = "bearerAuth")
     )
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -45,7 +48,7 @@ public interface UserSuggestedTemplateApi {
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
-            description = "등록 성공",
+            description = "등록 성공. 요청자가 구독자로 자동 등록됩니다.",
             content = @Content(
                 examples = @ExampleObject(
                     name = "SUCCESS",
@@ -53,15 +56,7 @@ public interface UserSuggestedTemplateApi {
                         {
                           "code": "2000",
                           "message": "요청에 성공하였습니다.",
-                          "data": {
-                            "id": 1,
-                            "videoLink": "https://youtu.be/abc12345678",
-                            "recommendReason": "산정호수 일출이 정말 아름다워요. 새벽 5시에 가면 혼자 볼 수 있어요.",
-                            "suggesterUuid": "uuid-1234-5678",
-                            "category": "UNCATEGORIZED",
-                            "region": "UNDEFINED",
-                            "status": "PENDING"
-                          }
+                          "data": {}
                         }
                         """
                 )
@@ -100,9 +95,44 @@ public interface UserSuggestedTemplateApi {
                         """
                 )
             )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = """
+                중복 요청 (에러 코드에 따라 다음 처리를 분기하세요)
+                - TRAVEL-03-003: 다른 사용자가 이미 요청한 영상. 추후 구독 API(POST /api/v1/suggested-templates/{id}/subscribe)를 통해 게시 알림 신청 가능
+                - TRAVEL-03-004: 본인이 이미 요청한 영상. 추가 처리 불필요
+                """,
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "ALREADY_EXISTS_SUGGESTED_TEMPLATE",
+                        summary = "다른 사용자가 이미 요청한 영상",
+                        value = """
+                            {
+                              "code": "TRAVEL-03-003",
+                              "message": "다른 사용자가 이미 요청한 영상입니다",
+                              "errors": []
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "ALREADY_REQUESTED_SUGGESTED_TEMPLATE",
+                        summary = "본인이 이미 요청한 영상",
+                        value = """
+                            {
+                              "code": "TRAVEL-03-004",
+                              "message": "이미 요청한 영상입니다",
+                              "errors": []
+                            }
+                            """
+                    )
+                }
+            )
         )
     })
-    ResponseEntity<SuccessResponse<UserSuggestedTemplateResponse>> createUserSuggestedTemplate(
+    ResponseEntity<SuccessResponse<?>> createUserSuggestedTemplate(
         @CurrentUuid String uuid,
         @RequestBody @Valid final CreateUserSuggestedTemplateRequest request
     );

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateApi.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateApi.java
@@ -1,0 +1,109 @@
+package com.yapp.ndgl.application.domains.travel.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
+import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UserSuggestedTemplateResponse;
+import com.yapp.ndgl.common.response.ErrorResponse;
+import com.yapp.ndgl.common.response.SuccessResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "User Suggested Template", description = "사용자 제안 여행 템플릿 API")
+public interface UserSuggestedTemplateApi {
+
+    @Operation(
+        summary = "여행 템플릿 제안 등록",
+        description = "사용자가 YouTube 영상 링크와 추천 이유를 입력하여 여행 템플릿을 제안합니다. 등록 시 상태는 PENDING으로 설정되며, 영상 URL 형식 유효성만 검증합니다.",
+        security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+        content = @Content(
+            examples = @ExampleObject(
+                name = "요청 예시",
+                value = """
+                    {
+                      "video_link": "https://youtu.be/abc12345678",
+                      "recommend_reason": "산정호수 일출이 정말 아름다워요. 새벽 5시에 가면 혼자 볼 수 있어요.",
+                      "category": "UNCATEGORIZED",
+                      "region": "UNDEFINED"
+                    }
+                    """
+            )
+        )
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "등록 성공",
+            content = @Content(
+                examples = @ExampleObject(
+                    name = "SUCCESS",
+                    value = """
+                        {
+                          "code": "2000",
+                          "message": "요청에 성공하였습니다.",
+                          "data": {
+                            "id": 1,
+                            "videoLink": "https://youtu.be/abc12345678",
+                            "recommendReason": "산정호수 일출이 정말 아름다워요. 새벽 5시에 가면 혼자 볼 수 있어요.",
+                            "suggesterUuid": "uuid-1234-5678",
+                            "category": "UNCATEGORIZED",
+                            "region": "UNDEFINED",
+                            "status": "PENDING"
+                          }
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 YouTube 영상 URL",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "INVALID_VIDEO_URL",
+                    value = """
+                        {
+                          "code": "YOUTUBE-01-001",
+                          "message": "유효하지 않은 YouTube 영상 URL입니다",
+                          "errors": []
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "UNAUTHORIZED",
+                    value = """
+                        {
+                          "code": "COMM-03-001",
+                          "message": "인증이 필요합니다",
+                          "errors": []
+                        }
+                        """
+                )
+            )
+        )
+    })
+    ResponseEntity<SuccessResponse<UserSuggestedTemplateResponse>> createUserSuggestedTemplate(
+        @CurrentUuid String uuid,
+        @RequestBody @Valid final CreateUserSuggestedTemplateRequest request
+    );
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateController.java
@@ -2,6 +2,7 @@ package com.yapp.ndgl.application.domains.travel.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +31,16 @@ public class UserSuggestedTemplateController implements UserSuggestedTemplateApi
         @Valid @RequestBody final CreateUserSuggestedTemplateRequest request
     ) {
         userSuggestedTemplateFacade.createUserSuggestedTemplate(uuid, request);
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+
+    @Override
+    @PostMapping("/{id}/subscribe")
+    public ResponseEntity<SuccessResponse<?>> subscribe(
+        @PathVariable("id") final Long templateId,
+        @CurrentUuid String uuid
+    ) {
+        userSuggestedTemplateFacade.subscribe(templateId, uuid);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateController.java
@@ -1,0 +1,35 @@
+package com.yapp.ndgl.application.domains.travel.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
+import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UserSuggestedTemplateResponse;
+import com.yapp.ndgl.application.domains.travel.facade.UserSuggestedTemplateFacade;
+import com.yapp.ndgl.common.response.SuccessResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/suggested-templates")
+@RestController
+public class UserSuggestedTemplateController {
+
+    private final UserSuggestedTemplateFacade userSuggestedTemplateFacade;
+
+    @PostMapping
+    public ResponseEntity<SuccessResponse<UserSuggestedTemplateResponse>> createUserSuggestedTemplate(
+        @CurrentUuid String uuid,
+        @Valid @RequestBody final CreateUserSuggestedTemplateRequest request
+    ) {
+        UserSuggestedTemplateResponse response = userSuggestedTemplateFacade.createUserSuggestedTemplate(uuid, request);
+        return ResponseEntity.ok(SuccessResponse.success(response));
+    }
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.yapp.ndgl.application.domains.auth.annotation.CurrentUuid;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
-import com.yapp.ndgl.application.domains.travel.controller.dto.UserSuggestedTemplateResponse;
 import com.yapp.ndgl.application.domains.travel.facade.UserSuggestedTemplateFacade;
 import com.yapp.ndgl.common.response.SuccessResponse;
 
@@ -26,11 +25,11 @@ public class UserSuggestedTemplateController implements UserSuggestedTemplateApi
 
     @Override
     @PostMapping
-    public ResponseEntity<SuccessResponse<UserSuggestedTemplateResponse>> createUserSuggestedTemplate(
+    public ResponseEntity<SuccessResponse<?>> createUserSuggestedTemplate(
         @CurrentUuid String uuid,
         @Valid @RequestBody final CreateUserSuggestedTemplateRequest request
     ) {
-        UserSuggestedTemplateResponse response = userSuggestedTemplateFacade.createUserSuggestedTemplate(uuid, request);
-        return ResponseEntity.ok(SuccessResponse.success(response));
+        userSuggestedTemplateFacade.createUserSuggestedTemplate(uuid, request);
+        return ResponseEntity.ok(SuccessResponse.noContent());
     }
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/UserSuggestedTemplateController.java
@@ -20,10 +20,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/suggested-templates")
 @RestController
-public class UserSuggestedTemplateController {
+public class UserSuggestedTemplateController implements UserSuggestedTemplateApi {
 
     private final UserSuggestedTemplateFacade userSuggestedTemplateFacade;
 
+    @Override
     @PostMapping
     public ResponseEntity<SuccessResponse<UserSuggestedTemplateResponse>> createUserSuggestedTemplate(
         @CurrentUuid String uuid,

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/CreateUserSuggestedTemplateRequest.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/CreateUserSuggestedTemplateRequest.java
@@ -1,0 +1,29 @@
+package com.yapp.ndgl.application.domains.travel.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yapp.ndgl.common.type.DomesticRegion;
+import com.yapp.ndgl.common.type.TravelCategory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateUserSuggestedTemplateRequest(
+    @Schema(description = "YouTube 영상 링크", example = "https://youtu.be/abc12345678", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "영상 링크는 필수입니다.")
+    @JsonProperty("video_link")
+    String videoLink,
+
+    @Schema(description = "추천 이유", example = "산정호수 일출 명소", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "추천 이유는 필수입니다.")
+    @Size(max = 1000, message = "추천 이유는 1000자 이하여야 합니다.")
+    @JsonProperty("recommend_reason")
+    String recommendReason,
+
+    @Schema(description = "여행 카테고리 (선택)", example = "UNCATEGORIZED")
+    TravelCategory category,
+
+    @Schema(description = "국내 지역 (선택)", example = "UNDEFINED")
+    DomesticRegion region
+) {
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/UserSuggestedTemplateResponse.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/UserSuggestedTemplateResponse.java
@@ -1,0 +1,44 @@
+package com.yapp.ndgl.application.domains.travel.controller.dto;
+
+import com.yapp.ndgl.common.type.DomesticRegion;
+import com.yapp.ndgl.common.type.SuggestionStatus;
+import com.yapp.ndgl.common.type.TravelCategory;
+import com.yapp.ndgl.domain.travel.UserSuggestedTemplate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UserSuggestedTemplateResponse(
+    @Schema(description = "제안 템플릿 ID", example = "1")
+    Long id,
+
+    @Schema(description = "영상 링크")
+    String videoLink,
+
+    @Schema(description = "추천 이유")
+    String recommendReason,
+
+    @Schema(description = "제안자 UUID")
+    String suggesterUuid,
+
+    @Schema(description = "여행 카테고리")
+    TravelCategory category,
+
+    @Schema(description = "국내 지역")
+    DomesticRegion region,
+
+    @Schema(description = "검토 상태")
+    SuggestionStatus status
+) {
+
+    public static UserSuggestedTemplateResponse from(final UserSuggestedTemplate domain) {
+        return new UserSuggestedTemplateResponse(
+            domain.getId(),
+            domain.getVideoLink(),
+            domain.getRecommendReason(),
+            domain.getSuggesterUuid(),
+            domain.getCategory(),
+            domain.getRegion(),
+            domain.getStatus()
+        );
+    }
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserSuggestedTemplateFacade.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserSuggestedTemplateFacade.java
@@ -2,7 +2,6 @@ package com.yapp.ndgl.application.domains.travel.facade;
 
 import com.yapp.ndgl.application.common.annotation.Facade;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
-import com.yapp.ndgl.application.domains.travel.controller.dto.UserSuggestedTemplateResponse;
 import com.yapp.ndgl.application.domains.travel.service.UserSuggestedTemplateService;
 
 import lombok.RequiredArgsConstructor;
@@ -13,10 +12,10 @@ public class UserSuggestedTemplateFacade {
 
     private final UserSuggestedTemplateService userSuggestedTemplateService;
 
-    public UserSuggestedTemplateResponse createUserSuggestedTemplate(
+    public void createUserSuggestedTemplate(
         final String uuid,
         final CreateUserSuggestedTemplateRequest request
     ) {
-        return userSuggestedTemplateService.createUserSuggestedTemplate(uuid, request);
+        userSuggestedTemplateService.createUserSuggestedTemplate(uuid, request);
     }
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserSuggestedTemplateFacade.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserSuggestedTemplateFacade.java
@@ -18,4 +18,8 @@ public class UserSuggestedTemplateFacade {
     ) {
         userSuggestedTemplateService.createUserSuggestedTemplate(uuid, request);
     }
+
+    public void subscribe(final Long templateId, final String uuid) {
+        userSuggestedTemplateService.subscribe(templateId, uuid);
+    }
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserSuggestedTemplateFacade.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserSuggestedTemplateFacade.java
@@ -1,0 +1,22 @@
+package com.yapp.ndgl.application.domains.travel.facade;
+
+import com.yapp.ndgl.application.common.annotation.Facade;
+import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UserSuggestedTemplateResponse;
+import com.yapp.ndgl.application.domains.travel.service.UserSuggestedTemplateService;
+
+import lombok.RequiredArgsConstructor;
+
+@Facade
+@RequiredArgsConstructor
+public class UserSuggestedTemplateFacade {
+
+    private final UserSuggestedTemplateService userSuggestedTemplateService;
+
+    public UserSuggestedTemplateResponse createUserSuggestedTemplate(
+        final String uuid,
+        final CreateUserSuggestedTemplateRequest request
+    ) {
+        return userSuggestedTemplateService.createUserSuggestedTemplate(uuid, request);
+    }
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
@@ -28,7 +28,6 @@ public class UserSuggestedTemplateService {
 
         String videoId = youTubeDataClient.extractVideoId(request.videoLink());
 
-
         userSuggestedTemplateDomainService.findByVideoId(videoId)
             .ifPresent(t -> {
                 if (t.getSuggesterUuid().equals(uuid)) {
@@ -49,5 +48,10 @@ public class UserSuggestedTemplateService {
         );
 
         log.info("새로운 여행 영상을 요청하였습니다. userId = {}, templateId = {}, video = {}", uuid, template.getId(), videoId);
+    }
+
+    public void subscribe(final Long templateId, final String uuid) {
+        log.info("사용자 제안 여행 템플릿 구독을 신청합니다. templateId = {}, subscriberUuid = {}", templateId, uuid);
+        userSuggestedTemplateDomainService.subscribe(templateId, uuid);
     }
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
@@ -3,7 +3,6 @@ package com.yapp.ndgl.application.domains.travel.service;
 import org.springframework.stereotype.Service;
 
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
-import com.yapp.ndgl.application.domains.travel.controller.dto.UserSuggestedTemplateResponse;
 import com.yapp.ndgl.clients.google.youtube.YouTubeDataClient;
 import com.yapp.ndgl.common.exception.GlobalException;
 import com.yapp.ndgl.common.exception.TravelErrorCode;
@@ -21,7 +20,7 @@ public class UserSuggestedTemplateService {
     private final UserSuggestedTemplateDomainService userSuggestedTemplateDomainService;
     private final YouTubeDataClient youTubeDataClient;
 
-    public UserSuggestedTemplateResponse createUserSuggestedTemplate(
+    public void createUserSuggestedTemplate(
         final String uuid,
         final CreateUserSuggestedTemplateRequest request
     ) {
@@ -29,11 +28,16 @@ public class UserSuggestedTemplateService {
 
         String videoId = youTubeDataClient.extractVideoId(request.videoLink());
 
-        if (userSuggestedTemplateDomainService.existsByVideoId(videoId)) {
-            throw new GlobalException(TravelErrorCode.ALREADY_EXISTS_SUGGESTED_TEMPLATE);
-        }
 
-        UserSuggestedTemplate saved = userSuggestedTemplateDomainService.create(
+        userSuggestedTemplateDomainService.findByVideoId(videoId)
+            .ifPresent(t -> {
+                if (t.getSuggesterUuid().equals(uuid)) {
+                    throw new GlobalException(TravelErrorCode.ALREADY_REQUESTED_SUGGESTED_TEMPLATE);
+                }
+                throw new GlobalException(TravelErrorCode.ALREADY_EXISTS_SUGGESTED_TEMPLATE);
+            });
+
+        UserSuggestedTemplate template = userSuggestedTemplateDomainService.create(
             UserSuggestedTemplate.of(
                 videoId,
                 request.videoLink(),
@@ -44,8 +48,6 @@ public class UserSuggestedTemplateService {
             )
         );
 
-        userSuggestedTemplateDomainService.addSubscriber(saved.getId(), uuid);
-
-        return UserSuggestedTemplateResponse.from(saved);
+        log.info("새로운 여행 영상을 요청하였습니다. userId = {}, templateId = {}, video = {}", uuid, template.getId(), videoId);
     }
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
@@ -1,0 +1,43 @@
+package com.yapp.ndgl.application.domains.travel.service;
+
+import org.springframework.stereotype.Service;
+
+import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
+import com.yapp.ndgl.application.domains.travel.controller.dto.UserSuggestedTemplateResponse;
+import com.yapp.ndgl.clients.google.youtube.YouTubeDataClient;
+import com.yapp.ndgl.domain.travel.UserSuggestedTemplate;
+import com.yapp.ndgl.domain.travel.service.UserSuggestedTemplateDomainService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserSuggestedTemplateService {
+
+    private final UserSuggestedTemplateDomainService userSuggestedTemplateDomainService;
+    private final YouTubeDataClient youTubeDataClient;
+
+    public UserSuggestedTemplateResponse createUserSuggestedTemplate(
+        final String uuid,
+        final CreateUserSuggestedTemplateRequest request
+    ) {
+        log.info("사용자 제안 여행 템플릿을 등록합니다. suggesterUuid = {}", uuid);
+
+        // 영상 URL 형식만 검증 (Gemini 분석은 별도 스코프)
+        youTubeDataClient.extractVideoId(request.videoLink());
+
+        UserSuggestedTemplate userSuggestedTemplate = userSuggestedTemplateDomainService.create(
+            UserSuggestedTemplate.of(
+                request.videoLink(),
+                request.recommendReason(),
+                uuid,
+                request.category(),
+                request.region()
+            )
+        );
+
+        return UserSuggestedTemplateResponse.from(userSuggestedTemplate);
+    }
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
@@ -25,11 +25,12 @@ public class UserSuggestedTemplateService {
     ) {
         log.info("사용자 제안 여행 템플릿을 등록합니다. suggesterUuid = {}", uuid);
 
-        // 영상 URL 형식만 검증 (Gemini 분석은 별도 스코프)
-        youTubeDataClient.extractVideoId(request.videoLink());
+        // 영상 URL 형식 검증 + videoId 추출 (Gemini 분석은 별도 스코프)
+        String videoId = youTubeDataClient.extractVideoId(request.videoLink());
 
         UserSuggestedTemplate userSuggestedTemplate = userSuggestedTemplateDomainService.create(
             UserSuggestedTemplate.of(
+                videoId,
                 request.videoLink(),
                 request.recommendReason(),
                 uuid,

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
 import com.yapp.ndgl.application.domains.travel.controller.dto.UserSuggestedTemplateResponse;
 import com.yapp.ndgl.clients.google.youtube.YouTubeDataClient;
+import com.yapp.ndgl.common.exception.GlobalException;
+import com.yapp.ndgl.common.exception.TravelErrorCode;
 import com.yapp.ndgl.domain.travel.UserSuggestedTemplate;
 import com.yapp.ndgl.domain.travel.service.UserSuggestedTemplateDomainService;
 
@@ -25,10 +27,13 @@ public class UserSuggestedTemplateService {
     ) {
         log.info("사용자 제안 여행 템플릿을 등록합니다. suggesterUuid = {}", uuid);
 
-        // 영상 URL 형식 검증 + videoId 추출 (Gemini 분석은 별도 스코프)
         String videoId = youTubeDataClient.extractVideoId(request.videoLink());
 
-        UserSuggestedTemplate userSuggestedTemplate = userSuggestedTemplateDomainService.create(
+        if (userSuggestedTemplateDomainService.existsByVideoId(videoId)) {
+            throw new GlobalException(TravelErrorCode.ALREADY_EXISTS_SUGGESTED_TEMPLATE);
+        }
+
+        UserSuggestedTemplate saved = userSuggestedTemplateDomainService.create(
             UserSuggestedTemplate.of(
                 videoId,
                 request.videoLink(),
@@ -39,6 +44,8 @@ public class UserSuggestedTemplateService {
             )
         );
 
-        return UserSuggestedTemplateResponse.from(userSuggestedTemplate);
+        userSuggestedTemplateDomainService.addSubscriber(saved.getId(), uuid);
+
+        return UserSuggestedTemplateResponse.from(saved);
     }
 }

--- a/clients/src/main/java/com/yapp/ndgl/clients/google/youtube/YouTubeDataClient.java
+++ b/clients/src/main/java/com/yapp/ndgl/clients/google/youtube/YouTubeDataClient.java
@@ -38,7 +38,7 @@ public class YouTubeDataClient {
 	 * 지원 형식: watch?v=, youtu.be/, embed/, shorts/
 	 */
 	private static final Pattern VIDEO_ID_PATTERN = Pattern.compile(
-		"(?:youtube\\.com/(?:watch\\?v=|embed/|shorts/)|youtu\\.be/)([A-Za-z0-9_-]{11})"
+		"(?:youtube\\.com/(?:watch\\?v=|embed/|shorts/)|youtu\\.be/)([A-Za-z0-9_-]{10,30})"
 	);
 
 	private final RestClient youTubeDataRestClient;

--- a/common/src/main/java/com/yapp/ndgl/common/exception/CommonErrorCode.java
+++ b/common/src/main/java/com/yapp/ndgl/common/exception/CommonErrorCode.java
@@ -36,6 +36,8 @@ public enum CommonErrorCode implements BaseErrorCode {
 	 * COMM-03-xxx
 	 * RESOURCE_CONFLICT
 	 */
+	DATA_INTEGRITY_VIOLATION(StatusCode.CONFLICT, DomainCode.COMM,
+		CategoryCode.RESOURCE_CONFLICT, "001", "중복된 요청입니다. 요청 가능 여부를 다시 확인해주세요."),
 
 	/**
 	 * COMM-04-xxx

--- a/common/src/main/java/com/yapp/ndgl/common/exception/TravelErrorCode.java
+++ b/common/src/main/java/com/yapp/ndgl/common/exception/TravelErrorCode.java
@@ -14,6 +14,8 @@ public enum TravelErrorCode implements BaseErrorCode {
         CategoryCode.RESOURCE_NOT_FOUND, "001", "여행 템플릿을 찾을 수 없습니다"),
     NOT_FOUND_USER_TRAVEL(StatusCode.NOT_FOUND, DomainCode.TRAVEL,
         CategoryCode.RESOURCE_NOT_FOUND, "002", "내 여행 정보를 찾을 수 없습니다"),
+    NOT_FOUND_SUGGESTED_TEMPLATE(StatusCode.NOT_FOUND, DomainCode.TRAVEL,
+        CategoryCode.RESOURCE_NOT_FOUND, "003", "요청된 여행 템플릿을 찾을 수 없습니다"),
 
     /**
      * TRAVEL-03-xxx
@@ -27,6 +29,8 @@ public enum TravelErrorCode implements BaseErrorCode {
         CategoryCode.RESOURCE_CONFLICT, "003", "다른 사용자가 이미 요청한 영상입니다."),
     ALREADY_REQUESTED_SUGGESTED_TEMPLATE(StatusCode.CONFLICT, DomainCode.TRAVEL,
         CategoryCode.RESOURCE_CONFLICT, "004", "이미 요청한 영상입니다"),
+    ALREADY_SUBSCRIBED_SUGGESTED_TEMPLATE(StatusCode.CONFLICT, DomainCode.TRAVEL,
+        CategoryCode.RESOURCE_CONFLICT, "005", "이미 알림 신청한 영상입니다"),
 
     /**
      * TRAVEL-04-xxx
@@ -37,7 +41,9 @@ public enum TravelErrorCode implements BaseErrorCode {
     INVALID_ITINERARY_REQUEST(StatusCode.BAD_REQUEST, DomainCode.TRAVEL,
         CategoryCode.BUSINESS_RULE_VIOLATION, "002", "여행 일정 요청 값이 올바르지 않습니다"),
     ALREADY_EXISTS_USER_TRAVEL_SCHEDULE(StatusCode.BAD_REQUEST, DomainCode.TRAVEL,
-        CategoryCode.BUSINESS_RULE_VIOLATION, "003", "이미 해당 기간에 내 여행 일정이 존재합니다");
+        CategoryCode.BUSINESS_RULE_VIOLATION, "003", "이미 해당 기간에 내 여행 일정이 존재합니다"),
+    NOT_SUBSCRIBABLE_SUGGESTED_TEMPLATE(StatusCode.BAD_REQUEST, DomainCode.TRAVEL,
+        CategoryCode.BUSINESS_RULE_VIOLATION, "004", "이미 처리된 영상은 구독할 수 없습니다");
 
     private final StatusCode statusCode;
     private final DomainCode domainCode;

--- a/common/src/main/java/com/yapp/ndgl/common/exception/TravelErrorCode.java
+++ b/common/src/main/java/com/yapp/ndgl/common/exception/TravelErrorCode.java
@@ -23,6 +23,8 @@ public enum TravelErrorCode implements BaseErrorCode {
         CategoryCode.RESOURCE_CONFLICT, "001", "이미 존재하는 여행 프로그램입니다"),
     ALREADY_EXISTS_TRAVEL_TEMPLATE(StatusCode.CONFLICT, DomainCode.TRAVEL,
         CategoryCode.RESOURCE_CONFLICT, "002", "이미 저장된 영상입니다"),
+    ALREADY_EXISTS_SUGGESTED_TEMPLATE(StatusCode.CONFLICT, DomainCode.TRAVEL,
+        CategoryCode.RESOURCE_CONFLICT, "003", "이미 요청된 영상입니다"),
 
     /**
      * TRAVEL-04-xxx

--- a/common/src/main/java/com/yapp/ndgl/common/exception/TravelErrorCode.java
+++ b/common/src/main/java/com/yapp/ndgl/common/exception/TravelErrorCode.java
@@ -24,7 +24,9 @@ public enum TravelErrorCode implements BaseErrorCode {
     ALREADY_EXISTS_TRAVEL_TEMPLATE(StatusCode.CONFLICT, DomainCode.TRAVEL,
         CategoryCode.RESOURCE_CONFLICT, "002", "이미 저장된 영상입니다"),
     ALREADY_EXISTS_SUGGESTED_TEMPLATE(StatusCode.CONFLICT, DomainCode.TRAVEL,
-        CategoryCode.RESOURCE_CONFLICT, "003", "이미 요청된 영상입니다"),
+        CategoryCode.RESOURCE_CONFLICT, "003", "다른 사용자가 이미 요청한 영상입니다."),
+    ALREADY_REQUESTED_SUGGESTED_TEMPLATE(StatusCode.CONFLICT, DomainCode.TRAVEL,
+        CategoryCode.RESOURCE_CONFLICT, "004", "이미 요청한 영상입니다"),
 
     /**
      * TRAVEL-04-xxx

--- a/common/src/main/java/com/yapp/ndgl/common/type/DomesticRegion.java
+++ b/common/src/main/java/com/yapp/ndgl/common/type/DomesticRegion.java
@@ -1,0 +1,12 @@
+package com.yapp.ndgl.common.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DomesticRegion {
+	UNDEFINED("미지정");
+
+	private final String label;
+}

--- a/common/src/main/java/com/yapp/ndgl/common/type/SuggestionStatus.java
+++ b/common/src/main/java/com/yapp/ndgl/common/type/SuggestionStatus.java
@@ -1,0 +1,14 @@
+package com.yapp.ndgl.common.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuggestionStatus {
+	PENDING("검토 대기"),
+	ACCEPTED("승인됨"),
+	DENIED("반려됨");
+
+	private final String label;
+}

--- a/common/src/main/java/com/yapp/ndgl/common/type/TravelCategory.java
+++ b/common/src/main/java/com/yapp/ndgl/common/type/TravelCategory.java
@@ -1,0 +1,12 @@
+package com.yapp.ndgl.common.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TravelCategory {
+	UNCATEGORIZED("미분류");
+
+	private final String label;
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/entity/UserSuggestedTemplateEntity.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/entity/UserSuggestedTemplateEntity.java
@@ -1,0 +1,62 @@
+package com.yapp.ndgl.domain.travel.entity;
+
+import com.yapp.ndgl.common.type.DomesticRegion;
+import com.yapp.ndgl.common.type.SuggestionStatus;
+import com.yapp.ndgl.common.type.TravelCategory;
+import com.yapp.ndgl.domain.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_suggested_templates")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSuggestedTemplateEntity extends BaseEntity {
+
+    @Column(name = "video_link", nullable = false, length = 500)
+    private String videoLink;
+
+    @Column(name = "recommend_reason", nullable = false, length = 1000)
+    private String recommendReason;
+
+    // NOTE: 사용자 시스템 정비 시 식별자 변경 가능성 있음 (UUID → User PK)
+    @Column(name = "suggester_uuid", nullable = false, length = 64)
+    private String suggesterUuid;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", length = 50)
+    private TravelCategory category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "region", length = 50)
+    private DomesticRegion region;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private SuggestionStatus status;
+
+    @Builder
+    public UserSuggestedTemplateEntity(
+        final String videoLink,
+        final String recommendReason,
+        final String suggesterUuid,
+        final TravelCategory category,
+        final DomesticRegion region,
+        final SuggestionStatus status
+    ) {
+        this.videoLink = videoLink;
+        this.recommendReason = recommendReason;
+        this.suggesterUuid = suggesterUuid;
+        this.category = category;
+        this.region = region;
+        this.status = status == null ? SuggestionStatus.PENDING : status;
+    }
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/entity/UserSuggestedTemplateEntity.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/entity/UserSuggestedTemplateEntity.java
@@ -21,6 +21,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSuggestedTemplateEntity extends BaseEntity {
 
+    @Column(name = "video_id", nullable = false, unique = true, length = 50)
+    private String videoId;
+
     @Column(name = "video_link", nullable = false, length = 500)
     private String videoLink;
 
@@ -45,6 +48,7 @@ public class UserSuggestedTemplateEntity extends BaseEntity {
 
     @Builder
     public UserSuggestedTemplateEntity(
+        final String videoId,
         final String videoLink,
         final String recommendReason,
         final String suggesterUuid,
@@ -52,6 +56,7 @@ public class UserSuggestedTemplateEntity extends BaseEntity {
         final DomesticRegion region,
         final SuggestionStatus status
     ) {
+        this.videoId = videoId;
         this.videoLink = videoLink;
         this.recommendReason = recommendReason;
         this.suggesterUuid = suggesterUuid;

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/entity/UserSuggestedTemplateSubscriberEntity.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/entity/UserSuggestedTemplateSubscriberEntity.java
@@ -1,0 +1,38 @@
+package com.yapp.ndgl.domain.travel.entity;
+
+import com.yapp.ndgl.domain.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "user_suggested_template_subscribers",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"template_id", "subscriber_uuid"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSuggestedTemplateSubscriberEntity extends BaseEntity {
+
+    @Column(name = "template_id", nullable = false)
+    private Long templateId;
+
+    // NOTE: 사용자 시스템 정비 시 식별자 변경 가능성 있음 (UUID → User PK)
+    @Column(name = "subscriber_uuid", nullable = false, length = 64)
+    private String subscriberUuid;
+
+    @Builder
+    public UserSuggestedTemplateSubscriberEntity(
+        final Long templateId,
+        final String subscriberUuid
+    ) {
+        this.templateId = templateId;
+        this.subscriberUuid = subscriberUuid;
+    }
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepository.java
@@ -1,5 +1,7 @@
 package com.yapp.ndgl.domain.travel.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
@@ -7,5 +9,5 @@ import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
 public interface UserSuggestedTemplateRepository
     extends JpaRepository<UserSuggestedTemplateEntity, Long> {
 
-    boolean existsByVideoId(String videoId);
+    Optional<UserSuggestedTemplateEntity> findByVideoId(String videoId);
 }

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepository.java
@@ -6,4 +6,6 @@ import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
 
 public interface UserSuggestedTemplateRepository
     extends JpaRepository<UserSuggestedTemplateEntity, Long> {
+
+    boolean existsByVideoId(String videoId);
 }

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepository.java
@@ -1,0 +1,9 @@
+package com.yapp.ndgl.domain.travel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
+
+public interface UserSuggestedTemplateRepository
+    extends JpaRepository<UserSuggestedTemplateEntity, Long> {
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateSubscriberRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateSubscriberRepository.java
@@ -6,4 +6,6 @@ import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateSubscriberEntity;
 
 public interface UserSuggestedTemplateSubscriberRepository
     extends JpaRepository<UserSuggestedTemplateSubscriberEntity, Long> {
+
+    boolean existsByTemplateIdAndSubscriberUuid(Long templateId, String subscriberUuid);
 }

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateSubscriberRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateSubscriberRepository.java
@@ -1,0 +1,9 @@
+package com.yapp.ndgl.domain.travel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateSubscriberEntity;
+
+public interface UserSuggestedTemplateSubscriberRepository
+    extends JpaRepository<UserSuggestedTemplateSubscriberEntity, Long> {
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/UserSuggestedTemplate.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/UserSuggestedTemplate.java
@@ -1,0 +1,38 @@
+package com.yapp.ndgl.domain.travel;
+
+import com.yapp.ndgl.common.type.DomesticRegion;
+import com.yapp.ndgl.common.type.SuggestionStatus;
+import com.yapp.ndgl.common.type.TravelCategory;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserSuggestedTemplate {
+
+    private Long id;
+    private String videoLink;
+    private String recommendReason;
+    private String suggesterUuid;
+    private TravelCategory category;
+    private DomesticRegion region;
+    private SuggestionStatus status;
+
+    public static UserSuggestedTemplate of(
+        final String videoLink,
+        final String recommendReason,
+        final String suggesterUuid,
+        final TravelCategory category,
+        final DomesticRegion region
+    ) {
+        return UserSuggestedTemplate.builder()
+            .videoLink(videoLink)
+            .recommendReason(recommendReason)
+            .suggesterUuid(suggesterUuid)
+            .category(category)
+            .region(region)
+            .status(SuggestionStatus.PENDING)
+            .build();
+    }
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/UserSuggestedTemplate.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/UserSuggestedTemplate.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 public class UserSuggestedTemplate {
 
     private Long id;
+    private String videoId;
     private String videoLink;
     private String recommendReason;
     private String suggesterUuid;
@@ -20,6 +21,7 @@ public class UserSuggestedTemplate {
     private SuggestionStatus status;
 
     public static UserSuggestedTemplate of(
+        final String videoId,
         final String videoLink,
         final String recommendReason,
         final String suggesterUuid,
@@ -27,6 +29,7 @@ public class UserSuggestedTemplate {
         final DomesticRegion region
     ) {
         return UserSuggestedTemplate.builder()
+            .videoId(videoId)
             .videoLink(videoLink)
             .recommendReason(recommendReason)
             .suggesterUuid(suggesterUuid)

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/UserSuggestedTemplateSubscriber.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/UserSuggestedTemplateSubscriber.java
@@ -1,0 +1,23 @@
+package com.yapp.ndgl.domain.travel;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserSuggestedTemplateSubscriber {
+
+    private Long id;
+    private Long templateId;
+    private String subscriberUuid;
+
+    public static UserSuggestedTemplateSubscriber of(
+        final Long templateId,
+        final String subscriberUuid
+    ) {
+        return UserSuggestedTemplateSubscriber.builder()
+            .templateId(templateId)
+            .subscriberUuid(subscriberUuid)
+            .build();
+    }
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/UserSuggestedTemplateMapper.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/UserSuggestedTemplateMapper.java
@@ -1,0 +1,33 @@
+package com.yapp.ndgl.domain.travel.mapper;
+
+import com.yapp.ndgl.domain.travel.UserSuggestedTemplate;
+import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
+
+public class UserSuggestedTemplateMapper {
+
+    public static UserSuggestedTemplate toDomain(final UserSuggestedTemplateEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return UserSuggestedTemplate.builder()
+            .id(entity.getId())
+            .videoLink(entity.getVideoLink())
+            .recommendReason(entity.getRecommendReason())
+            .suggesterUuid(entity.getSuggesterUuid())
+            .category(entity.getCategory())
+            .region(entity.getRegion())
+            .status(entity.getStatus())
+            .build();
+    }
+
+    public static UserSuggestedTemplateEntity toEntity(final UserSuggestedTemplate domain) {
+        return UserSuggestedTemplateEntity.builder()
+            .videoLink(domain.getVideoLink())
+            .recommendReason(domain.getRecommendReason())
+            .suggesterUuid(domain.getSuggesterUuid())
+            .category(domain.getCategory())
+            .region(domain.getRegion())
+            .status(domain.getStatus())
+            .build();
+    }
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/UserSuggestedTemplateMapper.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/UserSuggestedTemplateMapper.java
@@ -11,6 +11,7 @@ public class UserSuggestedTemplateMapper {
         }
         return UserSuggestedTemplate.builder()
             .id(entity.getId())
+            .videoId(entity.getVideoId())
             .videoLink(entity.getVideoLink())
             .recommendReason(entity.getRecommendReason())
             .suggesterUuid(entity.getSuggesterUuid())
@@ -22,6 +23,7 @@ public class UserSuggestedTemplateMapper {
 
     public static UserSuggestedTemplateEntity toEntity(final UserSuggestedTemplate domain) {
         return UserSuggestedTemplateEntity.builder()
+            .videoId(domain.getVideoId())
             .videoLink(domain.getVideoLink())
             .recommendReason(domain.getRecommendReason())
             .suggesterUuid(domain.getSuggesterUuid())

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/UserSuggestedTemplateSubscriberMapper.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/UserSuggestedTemplateSubscriberMapper.java
@@ -1,0 +1,29 @@
+package com.yapp.ndgl.domain.travel.mapper;
+
+import com.yapp.ndgl.domain.travel.UserSuggestedTemplateSubscriber;
+import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateSubscriberEntity;
+
+public class UserSuggestedTemplateSubscriberMapper {
+
+    public static UserSuggestedTemplateSubscriber toDomain(
+        final UserSuggestedTemplateSubscriberEntity entity
+    ) {
+        if (entity == null) {
+            return null;
+        }
+        return UserSuggestedTemplateSubscriber.builder()
+            .id(entity.getId())
+            .templateId(entity.getTemplateId())
+            .subscriberUuid(entity.getSubscriberUuid())
+            .build();
+    }
+
+    public static UserSuggestedTemplateSubscriberEntity toEntity(
+        final UserSuggestedTemplateSubscriber domain
+    ) {
+        return UserSuggestedTemplateSubscriberEntity.builder()
+            .templateId(domain.getTemplateId())
+            .subscriberUuid(domain.getSubscriberUuid())
+            .build();
+    }
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
@@ -5,6 +5,9 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.yapp.ndgl.common.exception.GlobalException;
+import com.yapp.ndgl.common.exception.TravelErrorCode;
+import com.yapp.ndgl.common.type.SuggestionStatus;
 import com.yapp.ndgl.domain.travel.UserSuggestedTemplate;
 import com.yapp.ndgl.domain.travel.UserSuggestedTemplateSubscriber;
 import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
@@ -35,7 +38,7 @@ public class UserSuggestedTemplateDomainService {
 
         addSubscriber(templateSubscriber);
 
-        return UserSuggestedTemplateMapper.toDomain(templateEntity);
+        return UserSuggestedTemplateMapper.toDomain(savedTemplateEntity);
     }
 
     private UserSuggestedTemplateSubscriber addSubscriber(
@@ -46,6 +49,20 @@ public class UserSuggestedTemplateDomainService {
             suggestedTemplateSubscriber);
         UserSuggestedTemplateSubscriberEntity save = userSuggestedTemplateSubscriberRepository.save(entity);
         return UserSuggestedTemplateSubscriberMapper.toDomain(save);
+    }
+
+    @Transactional
+    public void subscribe(final Long templateId, final String subscriberUuid) {
+        UserSuggestedTemplateEntity template = userSuggestedTemplateRepository.findById(templateId)
+            .orElseThrow(() -> new GlobalException(TravelErrorCode.NOT_FOUND_SUGGESTED_TEMPLATE));
+
+        if (template.getStatus() != SuggestionStatus.PENDING) {
+            throw new GlobalException(TravelErrorCode.NOT_SUBSCRIBABLE_SUGGESTED_TEMPLATE);
+        }
+        if (userSuggestedTemplateSubscriberRepository.existsByTemplateIdAndSubscriberUuid(templateId, subscriberUuid)) {
+            throw new GlobalException(TravelErrorCode.ALREADY_SUBSCRIBED_SUGGESTED_TEMPLATE);
+        }
+        addSubscriber(UserSuggestedTemplateSubscriber.of(templateId, subscriberUuid));
     }
 
     @Transactional(readOnly = true)

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
@@ -3,6 +3,8 @@ package com.yapp.ndgl.domain.travel.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.yapp.ndgl.common.exception.GlobalException;
+import com.yapp.ndgl.common.exception.TravelErrorCode;
 import com.yapp.ndgl.domain.travel.UserSuggestedTemplate;
 import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
 import com.yapp.ndgl.domain.travel.mapper.UserSuggestedTemplateMapper;
@@ -18,6 +20,9 @@ public class UserSuggestedTemplateDomainService {
 
     @Transactional
     public UserSuggestedTemplate create(final UserSuggestedTemplate userSuggestedTemplate) {
+        if (userSuggestedTemplateRepository.existsByVideoId(userSuggestedTemplate.getVideoId())) {
+            throw new GlobalException(TravelErrorCode.ALREADY_EXISTS_SUGGESTED_TEMPLATE);
+        }
         UserSuggestedTemplateEntity entity = UserSuggestedTemplateMapper.toEntity(userSuggestedTemplate);
         UserSuggestedTemplateEntity saved = userSuggestedTemplateRepository.save(entity);
         return UserSuggestedTemplateMapper.toDomain(saved);

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
@@ -3,12 +3,14 @@ package com.yapp.ndgl.domain.travel.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.yapp.ndgl.common.exception.GlobalException;
-import com.yapp.ndgl.common.exception.TravelErrorCode;
 import com.yapp.ndgl.domain.travel.UserSuggestedTemplate;
+import com.yapp.ndgl.domain.travel.UserSuggestedTemplateSubscriber;
 import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
+import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateSubscriberEntity;
 import com.yapp.ndgl.domain.travel.mapper.UserSuggestedTemplateMapper;
+import com.yapp.ndgl.domain.travel.mapper.UserSuggestedTemplateSubscriberMapper;
 import com.yapp.ndgl.domain.travel.repository.UserSuggestedTemplateRepository;
+import com.yapp.ndgl.domain.travel.repository.UserSuggestedTemplateSubscriberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,14 +19,31 @@ import lombok.RequiredArgsConstructor;
 public class UserSuggestedTemplateDomainService {
 
     private final UserSuggestedTemplateRepository userSuggestedTemplateRepository;
+    private final UserSuggestedTemplateSubscriberRepository userSuggestedTemplateSubscriberRepository;
 
     @Transactional
     public UserSuggestedTemplate create(final UserSuggestedTemplate userSuggestedTemplate) {
-        if (userSuggestedTemplateRepository.existsByVideoId(userSuggestedTemplate.getVideoId())) {
-            throw new GlobalException(TravelErrorCode.ALREADY_EXISTS_SUGGESTED_TEMPLATE);
-        }
         UserSuggestedTemplateEntity entity = UserSuggestedTemplateMapper.toEntity(userSuggestedTemplate);
         UserSuggestedTemplateEntity saved = userSuggestedTemplateRepository.save(entity);
         return UserSuggestedTemplateMapper.toDomain(saved);
+    }
+
+    @Transactional
+    public UserSuggestedTemplateSubscriber addSubscriber(
+        final Long templateId,
+        final String subscriberUuid
+    ) {
+        UserSuggestedTemplateSubscriberEntity entity =
+            UserSuggestedTemplateSubscriberMapper.toEntity(
+                UserSuggestedTemplateSubscriber.of(templateId, subscriberUuid)
+            );
+        UserSuggestedTemplateSubscriberEntity saved =
+            userSuggestedTemplateSubscriberRepository.save(entity);
+        return UserSuggestedTemplateSubscriberMapper.toDomain(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByVideoId(final String videoId) {
+        return userSuggestedTemplateRepository.existsByVideoId(videoId);
     }
 }

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
@@ -1,0 +1,25 @@
+package com.yapp.ndgl.domain.travel.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.yapp.ndgl.domain.travel.UserSuggestedTemplate;
+import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
+import com.yapp.ndgl.domain.travel.mapper.UserSuggestedTemplateMapper;
+import com.yapp.ndgl.domain.travel.repository.UserSuggestedTemplateRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserSuggestedTemplateDomainService {
+
+    private final UserSuggestedTemplateRepository userSuggestedTemplateRepository;
+
+    @Transactional
+    public UserSuggestedTemplate create(final UserSuggestedTemplate userSuggestedTemplate) {
+        UserSuggestedTemplateEntity entity = UserSuggestedTemplateMapper.toEntity(userSuggestedTemplate);
+        UserSuggestedTemplateEntity saved = userSuggestedTemplateRepository.save(entity);
+        return UserSuggestedTemplateMapper.toDomain(saved);
+    }
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
@@ -1,5 +1,7 @@
 package com.yapp.ndgl.domain.travel.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,27 +25,32 @@ public class UserSuggestedTemplateDomainService {
 
     @Transactional
     public UserSuggestedTemplate create(final UserSuggestedTemplate userSuggestedTemplate) {
-        UserSuggestedTemplateEntity entity = UserSuggestedTemplateMapper.toEntity(userSuggestedTemplate);
-        UserSuggestedTemplateEntity saved = userSuggestedTemplateRepository.save(entity);
-        return UserSuggestedTemplateMapper.toDomain(saved);
+        UserSuggestedTemplateEntity templateEntity = UserSuggestedTemplateMapper.toEntity(userSuggestedTemplate);
+        UserSuggestedTemplateEntity savedTemplateEntity = userSuggestedTemplateRepository.save(templateEntity);
+
+        UserSuggestedTemplateSubscriber templateSubscriber = UserSuggestedTemplateSubscriber.of(
+            savedTemplateEntity.getId(),
+            templateEntity.getSuggesterUuid()
+        );
+
+        addSubscriber(templateSubscriber);
+
+        return UserSuggestedTemplateMapper.toDomain(templateEntity);
     }
 
-    @Transactional
-    public UserSuggestedTemplateSubscriber addSubscriber(
-        final Long templateId,
-        final String subscriberUuid
+    private UserSuggestedTemplateSubscriber addSubscriber(
+       final UserSuggestedTemplateSubscriber suggestedTemplateSubscriber
     ) {
-        UserSuggestedTemplateSubscriberEntity entity =
-            UserSuggestedTemplateSubscriberMapper.toEntity(
-                UserSuggestedTemplateSubscriber.of(templateId, subscriberUuid)
-            );
-        UserSuggestedTemplateSubscriberEntity saved =
-            userSuggestedTemplateSubscriberRepository.save(entity);
-        return UserSuggestedTemplateSubscriberMapper.toDomain(saved);
+
+        UserSuggestedTemplateSubscriberEntity entity = UserSuggestedTemplateSubscriberMapper.toEntity(
+            suggestedTemplateSubscriber);
+        UserSuggestedTemplateSubscriberEntity save = userSuggestedTemplateSubscriberRepository.save(entity);
+        return UserSuggestedTemplateSubscriberMapper.toDomain(save);
     }
 
     @Transactional(readOnly = true)
-    public boolean existsByVideoId(final String videoId) {
-        return userSuggestedTemplateRepository.existsByVideoId(videoId);
+    public Optional<UserSuggestedTemplate> findByVideoId(final String videoId) {
+        return userSuggestedTemplateRepository.findByVideoId(videoId)
+            .map(UserSuggestedTemplateMapper::toDomain);
     }
 }


### PR DESCRIPTION
🤖 **이 PR은 AI를 사용하여 자동 생성되었습니다.**
## 요약
사용자가 YouTube 영상 링크로 여행 템플릿을 제안하고, 제안된 영상에 대해 게시 알림을 구독할 수 있는 기능을 추가합니다. 중복/상태 검증과 자동 구독 등록으로 운영상 혼선을 줄이는 목적입니다.
## 변경 내용
- 사용자 제안 여행 템플릿 생성·구독 API를 추가
- 제안 템플릿 도메인 모델 및 DB 엔티티·구독자 모델을 추가
- 리포지토리와 도메인 서비스(생성·구독 로직)를 추가
- 제안 관련 에러 코드와 제안 상태·카테고리·지역 타입을 추가
- YouTube 링크 유효성 검사 및 영상 ID 추출 로직을 변경
## 참고 사항
등록 시 요청자는 자동으로 구독자로 추가되며, 중복 또는 처리 상태에 따른 명확한 에러 코드가 반환됩니다.
