### PR TITLE
feat: [NDGL-133] 어드민 페이지 사용자 요청 컨텐츠 목록 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ CODEX.md
 
 ### ENV File ###
 .env
+
+docs
+
+### macOS ###
+.DS_Store

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     // Transaction
     implementation 'org.springframework:spring-tx'
 
+    // Spring Data (Page, Pageable)
+    implementation 'org.springframework.data:spring-data-commons'
+
     // Thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 

--- a/application/src/main/java/com/yapp/ndgl/application/domains/admin/controller/AdminUserSuggestedTemplateViewController.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/admin/controller/AdminUserSuggestedTemplateViewController.java
@@ -1,0 +1,61 @@
+package com.yapp.ndgl.application.domains.admin.controller;
+
+import java.util.List;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.yapp.ndgl.application.domains.travel.controller.dto.AdminUserSuggestedTemplateResponse;
+import com.yapp.ndgl.application.domains.travel.facade.UserSuggestedTemplateFacade;
+import com.yapp.ndgl.common.response.PageResponse;
+import com.yapp.ndgl.common.type.SuggestionStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequestMapping("/admin/user-suggested-templates")
+@RequiredArgsConstructor
+public class AdminUserSuggestedTemplateViewController {
+
+    private final UserSuggestedTemplateFacade userSuggestedTemplateFacade;
+
+    @GetMapping
+    public String listPage(
+        @RequestParam(value = "status", required = false) SuggestionStatus status,
+        @RequestParam(value = "page", defaultValue = "0") int page,
+        @RequestParam(value = "size", defaultValue = "12") int size,
+        Model model
+    ) {
+        try {
+            PageResponse<AdminUserSuggestedTemplateResponse> result =
+                userSuggestedTemplateFacade.readUserSuggestedTemplatesForAdmin(status, page, size);
+            model.addAttribute("templates", result.getContent());
+            model.addAttribute("hasNext", result.isHasNext());
+            model.addAttribute("hasPrevious", result.isHasPrevious());
+            model.addAttribute("totalElements", result.getTotalElements());
+            model.addAttribute("totalPages", result.getTotalPages());
+            model.addAttribute("currentPage", page);
+            model.addAttribute("size", size);
+            model.addAttribute("status", status);
+            model.addAttribute("statuses", SuggestionStatus.values());
+        } catch (Exception e) {
+            log.error("사용자 제안 템플릿 목록 조회 실패", e);
+            model.addAttribute("errorMessage", "목록을 불러오는 중 오류가 발생했습니다.");
+            model.addAttribute("templates", List.of());
+            model.addAttribute("hasNext", false);
+            model.addAttribute("hasPrevious", false);
+            model.addAttribute("totalElements", 0L);
+            model.addAttribute("totalPages", 0);
+            model.addAttribute("currentPage", page);
+            model.addAttribute("size", size);
+            model.addAttribute("status", status);
+            model.addAttribute("statuses", SuggestionStatus.values());
+        }
+        return "admin/user-suggested-template-list";
+    }
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/AdminUserSuggestedTemplateResponse.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/controller/dto/AdminUserSuggestedTemplateResponse.java
@@ -1,0 +1,35 @@
+package com.yapp.ndgl.application.domains.travel.controller.dto;
+
+import java.time.LocalDateTime;
+
+import com.yapp.ndgl.common.type.DomesticRegion;
+import com.yapp.ndgl.common.type.SuggestionStatus;
+import com.yapp.ndgl.common.type.TravelCategory;
+import com.yapp.ndgl.domain.travel.UserSuggestedTemplate;
+
+public record AdminUserSuggestedTemplateResponse(
+    Long id,
+    String videoId,
+    String videoLink,
+    String recommendReason,
+    String suggesterUuid,
+    TravelCategory category,
+    DomesticRegion region,
+    SuggestionStatus status,
+    LocalDateTime createdAt
+) {
+
+    public static AdminUserSuggestedTemplateResponse toResponse(final UserSuggestedTemplate domain) {
+        return new AdminUserSuggestedTemplateResponse(
+            domain.getId(),
+            domain.getVideoId(),
+            domain.getVideoLink(),
+            domain.getRecommendReason(),
+            domain.getSuggesterUuid(),
+            domain.getCategory(),
+            domain.getRegion(),
+            domain.getStatus(),
+            domain.getCreatedAt()
+        );
+    }
+}

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserSuggestedTemplateFacade.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/facade/UserSuggestedTemplateFacade.java
@@ -1,13 +1,18 @@
 package com.yapp.ndgl.application.domains.travel.facade;
 
 import com.yapp.ndgl.application.common.annotation.Facade;
+import com.yapp.ndgl.application.domains.travel.controller.dto.AdminUserSuggestedTemplateResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
 import com.yapp.ndgl.application.domains.travel.event.publisher.UserSuggestedTemplateEventPublisher;
 import com.yapp.ndgl.application.domains.travel.service.UserSuggestedTemplateService;
 import com.yapp.ndgl.application.utils.YoutubeUrlParser;
+import com.yapp.ndgl.common.response.PageResponse;
+import com.yapp.ndgl.common.type.SuggestionStatus;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Facade
 @RequiredArgsConstructor
 public class UserSuggestedTemplateFacade {
@@ -27,5 +32,12 @@ public class UserSuggestedTemplateFacade {
 
     public void subscribe(final Long templateId, final String uuid) {
         userSuggestedTemplateService.subscribe(templateId, uuid);
+    }
+
+    public PageResponse<AdminUserSuggestedTemplateResponse> readUserSuggestedTemplatesForAdmin(
+        final SuggestionStatus status, final int page, final int size
+    ) {
+        log.info("어드민 사용자 제안 템플릿 목록을 조회합니다. status = {}, page = {}, size = {}", status, page, size);
+        return userSuggestedTemplateService.readUserSuggestedTemplatesForAdmin(status, page, size);
     }
 }

--- a/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
+++ b/application/src/main/java/com/yapp/ndgl/application/domains/travel/service/UserSuggestedTemplateService.java
@@ -1,11 +1,14 @@
 package com.yapp.ndgl.application.domains.travel.service;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.yapp.ndgl.application.domains.travel.controller.dto.AdminUserSuggestedTemplateResponse;
 import com.yapp.ndgl.application.domains.travel.controller.dto.CreateUserSuggestedTemplateRequest;
 import com.yapp.ndgl.common.exception.GlobalException;
 import com.yapp.ndgl.common.exception.TravelErrorCode;
+import com.yapp.ndgl.common.response.PageResponse;
 import com.yapp.ndgl.common.type.SuggestionStatus;
 import com.yapp.ndgl.domain.travel.UserSuggestedTemplate;
 import com.yapp.ndgl.application.common.annotation.DistributedLock;
@@ -63,5 +66,20 @@ public class UserSuggestedTemplateService {
     public void subscribe(final Long templateId, final String uuid) {
         log.info("사용자 제안 여행 템플릿 구독을 신청합니다. templateId={}, subscriberUuid={}", templateId, uuid);
         userSuggestedTemplateDomainService.subscribe(templateId, uuid);
+    }
+
+    public PageResponse<AdminUserSuggestedTemplateResponse> readUserSuggestedTemplatesForAdmin(
+        final SuggestionStatus status, final int page, final int size
+    ) {
+        Page<AdminUserSuggestedTemplateResponse> result = userSuggestedTemplateDomainService
+            .findUserSuggestedTemplates(status, page, size)
+            .map(AdminUserSuggestedTemplateResponse::toResponse);
+
+        return PageResponse.of(
+            result.getContent(),
+            result.getNumber(),
+            result.getSize(),
+            result.getTotalElements()
+        );
     }
 }

--- a/application/src/main/resources/templates/admin/travel-template-list.html
+++ b/application/src/main/resources/templates/admin/travel-template-list.html
@@ -162,6 +162,7 @@
         <div class="header">
             <h1>여행 템플릿 목록</h1>
             <div class="nav-links">
+                <a href="/admin/user-suggested-templates" class="nav-link">사용자 제안 템플릿</a>
                 <a href="/admin/travel-templates/new" class="nav-link">+ 새 템플릿 등록</a>
                 <form action="/admin/logout" method="POST" style="margin:0;">
                     <button type="submit" class="logout-link" style="background:none; border:none; cursor:pointer; padding:0;">로그아웃</button>

--- a/application/src/main/resources/templates/admin/user-suggested-template-list.html
+++ b/application/src/main/resources/templates/admin/user-suggested-template-list.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>사용자 제안 영상 템플릿 - NDGL 관리자</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background-color: #f5f5f5;
+            min-height: 100vh;
+            padding: 24px;
+        }
+        .container { max-width: 1000px; margin: 0 auto; }
+        .header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 24px;
+        }
+        .header h1 { font-size: 24px; color: #333; }
+        .nav-links { display: flex; gap: 16px; align-items: center; }
+        .nav-link {
+            font-size: 14px;
+            color: #4a90d9;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        .nav-link:hover { text-decoration: underline; }
+        .logout-link { font-size: 14px; color: #888; text-decoration: none; }
+        .logout-link:hover { color: #cf1322; }
+        .card {
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+            padding: 24px;
+            margin-bottom: 16px;
+        }
+        .card h2 { font-size: 16px; color: #333; margin-bottom: 16px; padding-bottom: 12px; border-bottom: 1px solid #eee; }
+        .filter-bar {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+            margin-bottom: 16px;
+        }
+        .filter-bar label { font-size: 13px; color: #555; }
+        .filter-bar select {
+            font-size: 13px;
+            padding: 6px 10px;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            background: #fff;
+            cursor: pointer;
+        }
+        .template-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+            gap: 16px;
+        }
+        .template-card {
+            background: #fff;
+            border: 1px solid #e1e4e8;
+            border-radius: 10px;
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+        }
+        .template-thumbnail {
+            width: 100%;
+            height: 160px;
+            object-fit: cover;
+            background: #e8edf2;
+            display: block;
+        }
+        .template-body { padding: 14px; flex: 1; }
+        .template-reason {
+            font-size: 14px;
+            font-weight: 600;
+            color: #222;
+            margin-bottom: 8px;
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            line-height: 1.4;
+        }
+        .template-meta {
+            font-size: 12px;
+            color: #888;
+            margin-bottom: 8px;
+        }
+        .template-tags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }
+        .tag {
+            font-size: 11px;
+            padding: 3px 8px;
+            border-radius: 99px;
+            font-weight: 500;
+        }
+        .tag-category { background: #e8f4fd; color: #1a73e8; }
+        .tag-region { background: #fdf4ff; color: #9333ea; }
+        .badge-status {
+            display: inline-block;
+            font-size: 11px;
+            font-weight: 600;
+            padding: 3px 8px;
+            border-radius: 99px;
+            margin-left: 4px;
+        }
+        .badge-pending { background: #fffbe6; color: #d48806; }
+        .badge-accepted { background: #f0fdf4; color: #16a34a; }
+        .badge-denied { background: #fff2f0; color: #cf1322; }
+        .template-id { font-size: 11px; color: #bbb; margin-top: 8px; }
+        .card-footer {
+            padding: 10px 14px;
+            border-top: 1px solid #f0f0f0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .btn-link {
+            font-size: 12px;
+            padding: 5px 12px;
+            background: #f5f7fb;
+            color: #1a73e8;
+            border: 1px solid #d4e3fc;
+            border-radius: 6px;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        .btn-link:hover { background: #e8f0fe; }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 12px;
+            margin-top: 24px;
+        }
+        .page-btn {
+            padding: 8px 20px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            background: #fff;
+            font-size: 14px;
+            color: #555;
+            cursor: pointer;
+            text-decoration: none;
+        }
+        .page-btn:hover { background: #f5f5f5; }
+        .page-btn.disabled { color: #ccc; cursor: default; pointer-events: none; }
+        .page-info { font-size: 14px; color: #888; }
+        .empty-state {
+            text-align: center;
+            padding: 60px 0;
+            color: #aaa;
+            font-size: 15px;
+        }
+        .error-banner {
+            background: #fff2f0;
+            color: #cf1322;
+            border: 1px solid #ffccc7;
+            border-radius: 8px;
+            padding: 12px 16px;
+            font-size: 14px;
+            margin-bottom: 16px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>사용자 제안 영상 템플릿</h1>
+            <div class="nav-links">
+                <a href="/admin/travel-templates" class="nav-link">여행 템플릿 목록</a>
+                <form action="/admin/logout" method="POST" style="margin:0;">
+                    <button type="submit" class="logout-link" style="background:none; border:none; cursor:pointer; padding:0;">로그아웃</button>
+                </form>
+            </div>
+        </div>
+
+        <div th:if="${errorMessage}" class="error-banner" th:text="${errorMessage}"></div>
+
+        <div class="card">
+            <h2>신청된 영상 목록 <span th:if="${totalElements != null}" th:text="'(총 ' + ${totalElements} + '건)'"></span></h2>
+
+            <form method="GET" action="/admin/user-suggested-templates" class="filter-bar">
+                <label for="status-filter">상태 필터</label>
+                <select id="status-filter" name="status" onchange="this.form.submit()">
+                    <option value="" th:selected="${status == null}">전체</option>
+                    <option th:each="s : ${statuses}"
+                            th:value="${s.name()}"
+                            th:text="${s.label}"
+                            th:selected="${status != null and status.name() == s.name()}"></option>
+                </select>
+                <input type="hidden" name="size" th:value="${size}" />
+            </form>
+
+            <div th:if="${templates == null or #lists.isEmpty(templates)}" class="empty-state">
+                등록된 사용자 제안 템플릿이 없습니다.
+            </div>
+
+            <div class="template-grid" th:if="${templates != null and not #lists.isEmpty(templates)}">
+                <div th:each="t : ${templates}" class="template-card">
+                    <img th:src="'https://img.youtube.com/vi/' + ${t.videoId} + '/mqdefault.jpg'"
+                         class="template-thumbnail" alt="썸네일"
+                         onerror="this.style.display='none'">
+                    <div class="template-body">
+                        <div class="template-reason" th:text="${t.recommendReason}"></div>
+                        <div class="template-meta">
+                            <span th:text="${#temporals.format(t.createdAt, 'yyyy-MM-dd HH:mm')}"></span>
+                            <span class="badge-status"
+                                  th:classappend="${t.status.name() == 'PENDING'} ? 'badge-pending' : (${t.status.name() == 'ACCEPTED'} ? 'badge-accepted' : 'badge-denied')"
+                                  th:text="${t.status.label}"></span>
+                        </div>
+                        <div class="template-meta">
+                            제안자:
+                            <span th:text="${#strings.length(t.suggesterUuid) > 8 ? #strings.substring(t.suggesterUuid, 0, 8) + '…' : t.suggesterUuid}"></span>
+                        </div>
+                        <div class="template-tags">
+                            <span class="tag tag-category"
+                                  th:if="${t.category != null}"
+                                  th:text="${t.category}"></span>
+                            <span class="tag tag-region"
+                                  th:if="${t.region != null}"
+                                  th:text="${t.region}"></span>
+                        </div>
+                        <div class="template-id" th:text="'ID: ' + ${t.id}"></div>
+                    </div>
+                    <div class="card-footer">
+                        <span></span>
+                        <a th:href="${t.videoLink}" target="_blank" rel="noopener" class="btn-link">원본 영상 보기</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="pagination" th:if="${templates != null and not #lists.isEmpty(templates)}">
+            <a th:href="@{/admin/user-suggested-templates(status=${status != null ? status.name() : null}, page=${currentPage - 1}, size=${size})}"
+               class="page-btn"
+               th:classappend="${!hasPrevious} ? ' disabled'">&larr; 이전</a>
+            <span class="page-info" th:text="(${currentPage + 1}) + ' / ' + ${totalPages} + ' 페이지'"></span>
+            <a th:href="@{/admin/user-suggested-templates(status=${status != null ? status.name() : null}, page=${currentPage + 1}, size=${size})}"
+               class="page-btn"
+               th:classappend="${!hasNext} ? ' disabled'">다음 &rarr;</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/common/src/main/java/com/yapp/ndgl/common/response/PageResponse.java
+++ b/common/src/main/java/com/yapp/ndgl/common/response/PageResponse.java
@@ -1,0 +1,62 @@
+package com.yapp.ndgl.common.response;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageResponse<T> {
+
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+    private boolean hasPrevious;
+
+    @Builder
+    private PageResponse(
+        final List<T> content,
+        final int page,
+        final int size,
+        final long totalElements,
+        final int totalPages,
+        final boolean hasNext,
+        final boolean hasPrevious
+    ) {
+        this.content = content;
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.hasNext = hasNext;
+        this.hasPrevious = hasPrevious;
+    }
+
+    public static <T> PageResponse<T> of(
+        final List<T> content,
+        final int page,
+        final int size,
+        final long totalElements
+    ) {
+
+        int totalPages = (size == 0) ? 0 : (int) Math.ceil((double) totalElements / size);
+        boolean hasNext = page + 1 < totalPages;
+        boolean hasPrevious = page > 0;
+
+        return PageResponse.<T>builder()
+            .content(content)
+            .page(page)
+            .size(size)
+            .totalElements(totalElements)
+            .totalPages(totalPages)
+            .hasNext(hasNext)
+            .hasPrevious(hasPrevious)
+            .build();
+    }
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepository.java
@@ -8,7 +8,7 @@ import com.yapp.ndgl.common.type.SuggestionStatus;
 import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
 
 public interface UserSuggestedTemplateRepository
-    extends JpaRepository<UserSuggestedTemplateEntity, Long> {
+    extends JpaRepository<UserSuggestedTemplateEntity, Long>, UserSuggestedTemplateRepositoryCustom {
 
     Optional<UserSuggestedTemplateEntity> findFirstByVideoIdAndStatus(String videoId, SuggestionStatus status);
 }

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepositoryCustom.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.yapp.ndgl.domain.travel.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.yapp.ndgl.common.type.SuggestionStatus;
+import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
+
+public interface UserSuggestedTemplateRepositoryCustom {
+
+    Page<UserSuggestedTemplateEntity> findByStatus(SuggestionStatus status, Pageable pageable);
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepositoryImpl.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/travel/repository/UserSuggestedTemplateRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.yapp.ndgl.domain.travel.repository;
+
+import static com.yapp.ndgl.domain.travel.entity.QUserSuggestedTemplateEntity.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yapp.ndgl.common.type.SuggestionStatus;
+import com.yapp.ndgl.domain.travel.entity.UserSuggestedTemplateEntity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserSuggestedTemplateRepositoryImpl implements UserSuggestedTemplateRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<UserSuggestedTemplateEntity> findByStatus(
+        final SuggestionStatus status,
+        final Pageable pageable
+    ) {
+        BooleanBuilder where = new BooleanBuilder();
+        if (status != null) {
+            where.and(userSuggestedTemplateEntity.status.eq(status));
+        }
+
+        List<UserSuggestedTemplateEntity> content = queryFactory
+            .selectFrom(userSuggestedTemplateEntity)
+            .where(where)
+            .orderBy(userSuggestedTemplateEntity.createdAt.desc(), userSuggestedTemplateEntity.id.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        Long total = queryFactory
+            .select(userSuggestedTemplateEntity.count())
+            .from(userSuggestedTemplateEntity)
+            .where(where)
+            .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0L : total);
+    }
+}

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/UserSuggestedTemplate.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/UserSuggestedTemplate.java
@@ -1,5 +1,7 @@
 package com.yapp.ndgl.domain.travel;
 
+import java.time.LocalDateTime;
+
 import com.yapp.ndgl.common.type.DomesticRegion;
 import com.yapp.ndgl.common.type.SuggestionStatus;
 import com.yapp.ndgl.common.type.TravelCategory;
@@ -19,6 +21,7 @@ public class UserSuggestedTemplate {
     private TravelCategory category;
     private DomesticRegion region;
     private SuggestionStatus status;
+    private LocalDateTime createdAt;
 
     public static UserSuggestedTemplate of(
         final String videoId,

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/UserSuggestedTemplateMapper.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/mapper/UserSuggestedTemplateMapper.java
@@ -18,6 +18,7 @@ public class UserSuggestedTemplateMapper {
             .category(entity.getCategory())
             .region(entity.getRegion())
             .status(entity.getStatus())
+            .createdAt(entity.getCreatedAt())
             .build();
     }
 

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/travel/service/UserSuggestedTemplateDomainService.java
@@ -2,6 +2,9 @@ package com.yapp.ndgl.domain.travel.service;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,6 +71,15 @@ public class UserSuggestedTemplateDomainService {
     @Transactional(readOnly = true)
     public Optional<UserSuggestedTemplate> findByVideoIdAndStatus(final String videoId, final SuggestionStatus status) {
         return userSuggestedTemplateRepository.findFirstByVideoIdAndStatus(videoId, status)
+            .map(UserSuggestedTemplateMapper::toDomain);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserSuggestedTemplate> findUserSuggestedTemplates(
+        final SuggestionStatus status, final int page, final int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return userSuggestedTemplateRepository.findByStatus(status, pageable)
             .map(UserSuggestedTemplateMapper::toDomain);
     }
 }


### PR DESCRIPTION
> 🤖 **이 PR은 AI를 사용하여 자동 생성되었습니다.**
## 요약
관리자에서 사용자 제안 영상 템플릿을 조회·필터링·페이징할 수 있는 목록 페이지와 관련 백엔드 흐름을 추가합니다.

## 변경 내용
- 관리자용 사용자 제안 템플릿 목록 페이지와 네비게이션 링크를 추가
- 어드민용 목록 조회 API 및 응답 DTO(PageResponse 포함)를 추가
- 상태 기반 조회·페이징 지원을 위한 레포지토리 커스텀 쿼리와 페이징 구현을 추가
- 서비스·패사드에서 어드민 조회 흐름을 노출하도록 변경
- 빌드 의존성(spring-data-commons, thymeleaf)과 .gitignore 항목을 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 관리자 대시보드에 사용자 제안 템플릿 관리 페이지 추가
  * 상태별 필터링 및 페이지네이션 지원

* **Chores**
  * 환경 설정 파일 및 의존성 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YAPP-Github/NDGL-BE/pull/75)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->