### PR TITLE
feat: [NDGL-148] 유저 엔티티 소셜 로그인 필드 추가

### DIFF
--- a/common/src/main/java/com/yapp/ndgl/common/type/SocialProvider.java
+++ b/common/src/main/java/com/yapp/ndgl/common/type/SocialProvider.java
@@ -1,0 +1,13 @@
+package com.yapp.ndgl.common.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SocialProvider {
+    KAKAO("카카오"),
+    APPLE("애플");
+
+    private final String label;
+}

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/user/entity/UserEntity.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/user/entity/UserEntity.java
@@ -1,16 +1,23 @@
 package com.yapp.ndgl.domain.user.entity;
 
+import com.yapp.ndgl.common.type.SocialProvider;
 import com.yapp.ndgl.domain.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "users")
+@Table(
+    name = "users",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"})
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity extends BaseEntity {
@@ -18,7 +25,7 @@ public class UserEntity extends BaseEntity {
     @Column(nullable = false, unique = true, length = 36)
     private String uuid;
 
-    @Column(nullable = false, length = 500)
+    @Column(length = 500)
     private String fcmToken;
 
     @Column(length = 100)
@@ -36,6 +43,16 @@ public class UserEntity extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String nickname;
 
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private SocialProvider provider;
+
+    @Column(name = "provider_id", length = 100)
+    private String providerId;
+
+    @Column(length = 200)
+    private String email;
+
     @Builder
     public UserEntity(
         final String uuid,
@@ -44,7 +61,10 @@ public class UserEntity extends BaseEntity {
         final String deviceOs,
         final String deviceOsVersion,
         final String appVersion,
-        final String nickname
+        final String nickname,
+        final SocialProvider provider,
+        final String providerId,
+        final String email
     ) {
         this.uuid = uuid;
         this.fcmToken = fcmToken;
@@ -53,5 +73,8 @@ public class UserEntity extends BaseEntity {
         this.deviceOsVersion = deviceOsVersion;
         this.appVersion = appVersion;
         this.nickname = nickname;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.email = email;
     }
 }

--- a/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/user/repository/UserRepository.java
+++ b/domain/domain-rdb/src/main/java/com/yapp/ndgl/domain/user/repository/UserRepository.java
@@ -4,10 +4,12 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.yapp.ndgl.common.type.SocialProvider;
 import com.yapp.ndgl.domain.user.entity.UserEntity;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
-  Optional<UserEntity> findByUuid(String uuid);
+    Optional<UserEntity> findByUuid(String uuid);
 
+    Optional<UserEntity> findByProviderAndProviderId(SocialProvider provider, String providerId);
 }

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/User.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/User.java
@@ -3,6 +3,8 @@ package com.yapp.ndgl.domain.user;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.yapp.ndgl.common.type.SocialProvider;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,38 +12,51 @@ import lombok.Getter;
 @Builder
 public class User {
 
-  private final Long id;
-  private final String uuid;
-  private final String fcmToken;
-  private final String deviceModel;
-  private final String deviceOs;
-  private final String deviceOsVersion;
-  private final String appVersion;
-  private final String nickname;
-  private final LocalDateTime createdAt;
-  private final LocalDateTime updatedAt;
+    private final Long id;
+    private final String uuid;
+    private final String fcmToken;
+    private final String deviceModel;
+    private final String deviceOs;
+    private final String deviceOsVersion;
+    private final String appVersion;
+    private final String nickname;
+    private final SocialProvider provider;
+    private final String providerId;
+    private final String email;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
-  public static User create(
-      final String fcmToken,
-      final String deviceModel,
-      final String deviceOs,
-      final String deviceOsVersion,
-      final String appVersion,
-      final String nickname
-  ) {
-    String uuid = UUID.randomUUID().toString();
-    LocalDateTime now = LocalDateTime.now();
+    public static User create(
+        final String fcmToken,
+        final String deviceModel,
+        final String deviceOs,
+        final String deviceOsVersion,
+        final String appVersion,
+        final String nickname
+    ) {
+        return User.builder()
+            .uuid(UUID.randomUUID().toString())
+            .fcmToken(fcmToken)
+            .deviceModel(deviceModel)
+            .deviceOs(deviceOs)
+            .deviceOsVersion(deviceOsVersion)
+            .appVersion(appVersion)
+            .nickname(nickname)
+            .build();
+    }
 
-    return User.builder()
-        .uuid(uuid)
-        .fcmToken(fcmToken)
-        .deviceModel(deviceModel)
-        .deviceOs(deviceOs)
-        .deviceOsVersion(deviceOsVersion)
-        .appVersion(appVersion)
-        .nickname(nickname)
-        .createdAt(now)
-        .updatedAt(now)
-        .build();
-  }
+    public static User createSocialUser(
+        final SocialProvider provider,
+        final String providerId,
+        final String email,
+        final String nickname
+    ) {
+        return User.builder()
+            .uuid(UUID.randomUUID().toString())
+            .provider(provider)
+            .providerId(providerId)
+            .email(email)
+            .nickname(nickname)
+            .build();
+    }
 }

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/mapper/UserMapper.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/mapper/UserMapper.java
@@ -5,30 +5,36 @@ import com.yapp.ndgl.domain.user.entity.UserEntity;
 
 public class UserMapper {
 
-	public static UserEntity toEntity(final User user) {
-		return UserEntity.builder()
-			.uuid(user.getUuid())
-			.fcmToken(user.getFcmToken())
-			.deviceModel(user.getDeviceModel())
-			.deviceOs(user.getDeviceOs())
-			.deviceOsVersion(user.getDeviceOsVersion())
-			.appVersion(user.getAppVersion())
-			.nickname(user.getNickname())
-			.build();
-	}
+    public static UserEntity toEntity(final User user) {
+        return UserEntity.builder()
+            .uuid(user.getUuid())
+            .fcmToken(user.getFcmToken())
+            .deviceModel(user.getDeviceModel())
+            .deviceOs(user.getDeviceOs())
+            .deviceOsVersion(user.getDeviceOsVersion())
+            .appVersion(user.getAppVersion())
+            .nickname(user.getNickname())
+            .provider(user.getProvider())
+            .providerId(user.getProviderId())
+            .email(user.getEmail())
+            .build();
+    }
 
-	public static User toDomain(final UserEntity entity) {
-		return User.builder()
-			.id(entity.getId())
-			.uuid(entity.getUuid())
-			.fcmToken(entity.getFcmToken())
-			.deviceModel(entity.getDeviceModel())
-			.deviceOs(entity.getDeviceOs())
-			.deviceOsVersion(entity.getDeviceOsVersion())
-			.appVersion(entity.getAppVersion())
-			.nickname(entity.getNickname())
-			.createdAt(entity.getCreatedAt())
-			.updatedAt(entity.getUpdatedAt())
-			.build();
-	}
+    public static User toDomain(final UserEntity entity) {
+        return User.builder()
+            .id(entity.getId())
+            .uuid(entity.getUuid())
+            .fcmToken(entity.getFcmToken())
+            .deviceModel(entity.getDeviceModel())
+            .deviceOs(entity.getDeviceOs())
+            .deviceOsVersion(entity.getDeviceOsVersion())
+            .appVersion(entity.getAppVersion())
+            .nickname(entity.getNickname())
+            .provider(entity.getProvider())
+            .providerId(entity.getProviderId())
+            .email(entity.getEmail())
+            .createdAt(entity.getCreatedAt())
+            .updatedAt(entity.getUpdatedAt())
+            .build();
+    }
 }

--- a/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/service/UserDomainService.java
+++ b/domain/domain-service/src/main/java/com/yapp/ndgl/domain/user/service/UserDomainService.java
@@ -1,14 +1,17 @@
 package com.yapp.ndgl.domain.user.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.yapp.ndgl.common.exception.GlobalException;
 import com.yapp.ndgl.common.exception.UserErrorCode;
+import com.yapp.ndgl.common.type.SocialProvider;
 import com.yapp.ndgl.domain.user.User;
-import com.yapp.ndgl.domain.user.mapper.UserMapper;
 import com.yapp.ndgl.domain.user.UserNicknameGenerator;
 import com.yapp.ndgl.domain.user.entity.UserEntity;
+import com.yapp.ndgl.domain.user.mapper.UserMapper;
 import com.yapp.ndgl.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -28,18 +31,20 @@ public class UserDomainService {
         final String deviceOsVersion,
         final String appVersion) {
         String nickname = UserNicknameGenerator.generate();
-
-        User user = User.create(
-            fcmToken,
-            deviceModel,
-            deviceOs,
-            deviceOsVersion,
-            appVersion,
-            nickname
-        );
-
+        User user = User.create(fcmToken, deviceModel, deviceOs, deviceOsVersion, appVersion, nickname);
         UserEntity savedUserEntity = userRepository.save(UserMapper.toEntity(user));
         return UserMapper.toDomain(savedUserEntity);
+    }
+
+    @Transactional
+    public User createSocialUser(
+        final SocialProvider provider,
+        final String providerId,
+        final String email) {
+        String nickname = UserNicknameGenerator.generate();
+        User user = User.createSocialUser(provider, providerId, email, nickname);
+        UserEntity savedEntity = userRepository.save(UserMapper.toEntity(user));
+        return UserMapper.toDomain(savedEntity);
     }
 
     @Transactional(readOnly = true)
@@ -47,5 +52,13 @@ public class UserDomainService {
         return userRepository.findByUuid(uuid)
             .map(UserMapper::toDomain)
             .orElseThrow(() -> new GlobalException(UserErrorCode.NOT_FOUND_USER));
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<User> findByProviderAndProviderId(
+        final SocialProvider provider,
+        final String providerId) {
+        return userRepository.findByProviderAndProviderId(provider, providerId)
+            .map(UserMapper::toDomain);
     }
 }


### PR DESCRIPTION
> 🤖 **이 PR은 AI를 사용하여 자동 생성되었습니다.**

## 요약
소셜 로그인 정보를 도입해 소셜 사용자 생성/조회와 중복 방지를 지원하도록 도메인·DB·서비스를 확장합니다.

## 변경 내용
- SocialProvider enum을 추가
- User 엔티티에 provider, providerId, email 칼럼을 추가
- users 테이블에 (provider, providerId) 유니크 제약을 추가
- 도메인·매퍼·리포지토리·서비스에 소셜 사용자 생성/조회 흐름을 추가
- User 엔티티의 fcmToken 제약을 변경(nullable 허용)

## 참고 사항
기존 데이터에서 (provider, providerId) 중복 가능성 확인 및 마이그레이션 준비가 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 카카오 및 애플 소셜 로그인 서비스 통합
* 소셜 계정을 통한 신규 사용자 생성 및 기존 사용자 조회 기능 추가
* 소셜 로그인 사용자의 이메일 및 닉네임 정보 관리 지원

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YAPP-Github/NDGL-BE/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->